### PR TITLE
Fix widget spacing

### DIFF
--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -1028,7 +1028,9 @@ class RanaBrowser(QWidget):
         layout.addLayout(top_layout)
         layout.addWidget(self.rana_browser)
         self.setLayout(layout)
-        self.setMinimumWidth(800)
+        self.resize(800, self.height())
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+
         # Setup widgets that populate the rana widget
         self.projects_browser = ProjectsBrowser(
             communication=self.communication, parent=self


### PR DESCRIPTION
Initialize RanaBrowser with a width of 800; wich seems to be sufficient for the contents. Users can still resize it if needed. Note that refreshing after resize will start the widget with the resized size, not the size in the code.

Tested this quickly on my laptop and it seemed to take up the same space.
