### PR TITLE
Replace assert with a safer test

### DIFF
--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -412,7 +412,8 @@ class FileView(QWidget):
         self.file_showed.emit()
 
     def refresh(self):
-        assert self.selected_file
+        if not self.selected_file.get("id"):
+            return
         self.selected_file = get_tenant_project_file(
             self.project["id"], {"path": self.selected_file["id"]}
         )


### PR DESCRIPTION
I don't fully understand what happened in this report. But to prevent a full out crash in the future I replaced the assert with a safe check for the 'id' key in the selected file. In case no file is selected, somehow, no refresh will be performed.