### PR TITLE
Fix decreasing dock widget width

### DIFF
--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -330,9 +330,7 @@ class FileView(QWidget):
         button_layout.addWidget(btn_show_revisions)
         self.file_action_btn_dict = self.get_file_action_buttons()
         file_action_btn_layout = QHBoxLayout()
-        file_action_btn_layout.setContentsMargins(0, 0, 0, 0)
         for btn in self.file_action_btn_dict.values():
-            btn.hide()  # hide buttons by default to prevent big width in size hint
             file_action_btn_layout.addWidget(btn)
         layout = QVBoxLayout(self)
         layout.addWidget(self.file_table_widget)
@@ -353,6 +351,9 @@ class FileView(QWidget):
                 btn.clicked.connect(
                     lambda _, signal=action_signal: signal.emit(self.selected_file)
                 )
+            # hide buttons by default to prevent big width in size hint
+            # update_file_action_buttons ensures buttons are correctly shown on display
+            btn.hide()
             btn_dict[action] = btn
         return btn_dict
 


### PR DESCRIPTION
Decreasing the dock widget was blocked because adding all possible file action buttons to one layout resulted in a layout with a large minimum size. This is now fixed by wrapping a QWidget around the layout and set the minimum width for that widget. Note that there is no case where all these buttons are shown together, so the minimum size doesn't make sense. 

@benvanbasten-ns I know we shouldn't add stuff, but I thinks this is a bugfix that should be on main.