### PR TITLE
Fix project sorting on refresh

### DIFF
--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -823,8 +823,8 @@ class ProjectsBrowser(QWidget):
         self.avatar_cache.update_users_in_thread(self.users)
         self.setup_ui()
         self.populate_contributors()
+        self.sort_projects(2, Qt.SortOrder.AscendingOrder, populate=False)
         self.populate_projects()
-        self.projects_tv.header().setSortIndicator(2, Qt.SortOrder.AscendingOrder)
 
     def set_project_from_id(self, project_id: str):
         for project in self.projects:
@@ -914,12 +914,12 @@ class ProjectsBrowser(QWidget):
         self.fetch_projects()
         self.update_users()
         self.avatar_cache.update_users_in_thread(self.users)
+        self.sort_projects(2, Qt.SortOrder.AscendingOrder, populate=False)
         if self.filter_active:
             self.filter_projects()
         else:
             self.populate_projects()
         self.populate_contributors()
-        self.projects_tv.header().setSortIndicator(2, Qt.SortOrder.DescendingOrder)
         self.projects_refreshed.emit()
 
     @property
@@ -974,7 +974,11 @@ class ProjectsBrowser(QWidget):
                     selected_projects.append(project)
             return selected_projects
 
-    def sort_projects(self, column_index: int, order: Qt.SortOrder):
+    def sort_projects(self, column_index: int, order: Qt.SortOrder, populate=True):
+        # Ensure indicator is set also on direct call
+        self.projects_tv.header().blockSignals(True)
+        self.projects_tv.header().setSortIndicator(column_index, order)
+        self.projects_tv.header().blockSignals(False)
         self.current_page = 1
         key_funcs = [
             lambda project: project["name"].lower(),
@@ -986,10 +990,11 @@ class ProjectsBrowser(QWidget):
             self.projects.sort(
                 key=key_func, reverse=(order == Qt.SortOrder.DescendingOrder)
             )
-        if self.filter_active:
-            self.filter_projects()
-            return
-        self.populate_projects()
+        if populate:
+            if self.filter_active:
+                self.filter_projects()
+            else:
+                self.populate_projects()
 
     def show_context_menu(self, position):
         # Get the index under the cursor


### PR DESCRIPTION
Problem: after project refresh projects are no longer sorted by date

Solution: enfore sorting after refresh using `sort_projects`:
- Added a `populate` argument to `sort_projects` to disable re-populating after sorting. Note that the default behavior is to re-populate because this method is linked to `projects_tv.header().sortIndicatorChanged`
- Directly call `sort_projects` on initialization and refresh with `populate=False` in order to keep the code more clean. I'd found it very confusing to finish the refresh with `sort_projects` and I'd wonder where populating would happen
