### PR TITLE
Fix file view rename issues

### DIFF
--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -571,7 +571,7 @@ class FileView(QWidget):
             if selected_file["data_type"] != "threedi_schematisation"
             else "N/A"
         )
-        self.filename_edit = EditLabel(filename)
+        self.filename_edit.setText(filename)
         self.filename_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         self.filename_edit.adjustSize()
 

--- a/rana_qgis_plugin/widgets/result_browser.py
+++ b/rana_qgis_plugin/widgets/result_browser.py
@@ -37,6 +37,7 @@ class ResultBrowser(QDialog):
         self.selected_crs = None
 
         self.download_raw_data_bx = QCheckBox("Download simulation results", self)
+        self.download_raw_data_bx.setChecked(True)
         layout.addWidget(self.download_raw_data_bx)
 
         results_group = QGroupBox("Download post-processing results", self)
@@ -188,7 +189,6 @@ class ResultBrowser(QDialog):
             self.pixelsize_box.setEnabled(False)
             self.crs_select_box.setEnabled(False)
             # check download raw data by default
-            self.download_raw_data_bx.setChecked(True)
 
         self.results_table.resizeColumnsToContents()
         layout.addWidget(results_group)


### PR DESCRIPTION
Improve stability of rename via file view:
* Update `self.selected_file` after rename
* Prevent that refreshing after deleting file on remote crashes the widget
* Disable rename button while renaming
* Disable refresh while renaming
* Instead of recreatin `self.filename_edit`, update its text

Leendert mentioned this error while testing, and I've seen it before. I think/hope it mainly has to do with reloading, but curious if there are any other reasons while this may happen:
```
RuntimeError: wrapped C/C++ object of type EditLabel has been deleted
```