### PR TITLE
Allow user to set identity provider

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ History
 - Add option to filter by contributor and show contributors in project view
 - Show Created at column for projects (#3025)
 - Ensured Results Analysis Tool window remains visible when scenarios are loaded. (#3350)
+- Don't show authentication related menu items on startup.
 
 
 1.2.2 (2026-01-12)

--- a/rana_qgis_plugin/communication.py
+++ b/rana_qgis_plugin/communication.py
@@ -100,6 +100,10 @@ class UICommunication:
         clicked_button_text = clicked_button.text()
         return clicked_button_text
 
+    @staticmethod
+    def input_ask(parent, title, label):
+        return QInputDialog.getText(parent, title, label)
+
     def pick_item(self, title, message, parent=None, *items):
         """Getting item from list of items."""
         if self.iface is None:

--- a/rana_qgis_plugin/constant.py
+++ b/rana_qgis_plugin/constant.py
@@ -9,7 +9,6 @@ COGNITO_AUTHENTICATION_ENDPOINT = "https://auth.lizard.net/oauth2/authorize"
 COGNITO_TOKEN_ENDPOINT = "https://auth.lizard.net/oauth2/token"
 COGNITO_USER_INFO_ENDPOINT = "https://auth.lizard.net/oauth2/userInfo"
 COGNITO_LOGOUT_ENDPOINT = "https://auth.lizard.net/logout"
-COGNITO_NENS_IDENTITY_PROVIDER = "NelenSchuurmans"
 
 SUPPORTED_DATA_TYPES = {
     "vector": "vector",

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -65,7 +65,7 @@ class RanaQgisPlugin:
         QgsApplication.processingRegistry().addProvider(self.provider)
 
     def login(self, start_tenant_id: str = None) -> bool:
-        if not setup_oauth2(self.communication):
+        if not setup_oauth2(self.communication, start_tenant_id):
             return False
         self.add_rana_menu(True)
         if not self.set_tenant(start_tenant_id):
@@ -92,7 +92,7 @@ class RanaQgisPlugin:
                 return True
             if not self.tenants:
                 return False
-
+            # Take first
             tenant_id = self.tenants[0]["id"]
         else:
             # Extra check to see whether requested tenant is in list.
@@ -223,7 +223,8 @@ class RanaQgisPlugin:
             if not self.login(path_params["tenant_id"]):
                 return
         else:
-            self.login()
+            if not self.login():
+                return
         if not self.dock_widget:
             # Setup GUI
             self.dock_widget = QDockWidget(PLUGIN_NAME, self.iface.mainWindow())
@@ -374,3 +375,5 @@ class RanaQgisPlugin:
                 project_id=path_params["project_id"],
                 online_path=query_params["path"][0],
             )
+
+        self.rana_browser.refresh()

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -59,7 +59,7 @@ class RanaQgisPlugin:
 
     def initGui(self):
         """Create the (initial) menu entries and toolbar icons inside the QGIS GUI."""
-        self.add_rana_menu(True)
+        self.add_rana_menu(False)
         self.toolbar.addAction(self.action)
         self.provider = RanaQgisPluginProvider()
         QgsApplication.processingRegistry().addProvider(self.provider)
@@ -80,7 +80,7 @@ class RanaQgisPlugin:
         self.communication.clear_message_bar()
         remove_authcfg()
         set_tenant_id("")
-        self.add_rana_menu(True)
+        self.add_rana_menu(False)
         self.communication.bar_info("You have been logged out.")
         if self.dock_widget:
             self.dock_widget.close()

--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -1893,6 +1893,8 @@ class RanaBrowser(QWidget):
                 project_id, {"path": online_path}
             )
         if self.files_browser.selected_item:
+            self.files_browser.project = self.projects_browser.project
+            self.file_view.project = self.projects_browser.project
             paths = [self.projects_browser.project["name"]] + online_path.split("/")[
                 :-1
             ]


### PR DESCRIPTION
Currently, we always assume the user wants to login with Nelen&Schuurmans SSO, however, for some tenants multiple identity providers are possible. These possible providers can be retrieved per tenant from the API.

Furthermore, I've add a small bugfix in start_file_in_qgis(). The current project was not yet properly set in the FileView widget. (it is currently stored at several places, we might want to consider storing that session info in a shared object).