### PR TITLE
Fix crash on switching organisation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ History
 - Limit list of organisations shown in simulation wizard to the threedi organisations linked to the rana organisations (nens/rana-qgis-plugin#243)
 - Several improvements to information shown for a rana schematisation file (nens/rana-qgis-plugin#253)
 - Added status to file detail view (red for failed processing) and added additional checks (nens/rana-qgis-plugin#3496)
+- Reset RanaBrowser on switching organisation (nens/rana#3438)
+- Disable breadcrumbs when RanaBrowser is disabled
 
 
 1.2.4 (2026-01-28)

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -153,7 +153,7 @@ class RanaQgisPlugin:
                     f"Organisation set to: {selected_tenant_id}"
                 )
                 if self.rana_browser:
-                    self.rana_browser.refresh()
+                    self.rana_browser.reset()
 
     def add_rana_menu(self, show_authentication: bool):
         """Add Rana menu to the main menu bar."""

--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -1072,10 +1072,12 @@ class RanaBrowser(QWidget):
 
     @pyqtSlot()
     def enable(self):
+        self.breadcrumbs_stack.currentWidget().setEnabled(True)
         self.rana_browser.setEnabled(True)
 
     @pyqtSlot()
     def disable(self):
+        self.breadcrumbs_stack.currentWidget().setEnabled(False)
         self.rana_browser.setEnabled(False)
 
     def on_project_tab_changed(self, index):
@@ -1106,6 +1108,14 @@ class RanaBrowser(QWidget):
         if current_widget and hasattr(current_widget, "refresh"):
             current_widget.refresh()
             self.last_refresh_time = time.time()
+
+    def reset(self):
+        self.disable()
+        self.rana_browser.setCurrentIndex(0)
+        for widget_idx in range(self.breadcrumbs_stack.count()):
+            self.breadcrumbs_stack.widget(widget_idx).back_to_root()
+        self.projects_browser.refresh()
+        self.enable()
 
     @pyqtSlot()
     def refresh(self):


### PR DESCRIPTION
* Add reset method to RanaBrowser which is called switching organisation
* Add disabling/enabling breadcrumbs to `RanaBrowser.disable` and `RanaBrowser.enable`

Note this PR duplicates https://github.com/nens/rana-qgis-plugin/pull/261 but that diverged to much for merging