### PR TITLE
Remove confirmation dialog on opening already downloaded schematisation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ History
 - Prevent deleting results replacing an existing revision (nens/rana-qgis-plugin#259)
 - Create model when creating new schematisation (nens/rana#3533)
 - Add cancel button for running simulations (nens/rana-qgis-plugin#235)
+- Remove confirmation dialog on opening downloaded schematisations (nens/rana#289)
 
 
 1.2.6 (2026-02-19)

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -178,22 +178,6 @@ class Loader(QObject):
         data_type = file["data_type"]
         if data_type in SUPPORTED_DATA_TYPES.keys():
             _, local_file_path = get_local_file_path(project["slug"], file["id"])
-            if (
-                file["data_type"] == "threedi_schematisation"
-                and Path(local_file_path).exists()
-            ):
-                confirm_download = QMessageBox.question(
-                    self.parent(),
-                    "Confirm Download",
-                    f"{file['id']} already exists locally. Do you want to download it again?",
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                    QMessageBox.StandardButton.No,
-                )
-                if confirm_download == QMessageBox.StandardButton.No:
-                    self.on_file_download_finished(
-                        project, file, local_file_path, from_thread=False
-                    )
-                    return
             self.initialize_file_download_worker(project, file)
             self.file_download_worker.start()
         else:


### PR DESCRIPTION
Remove the confirmation dialog that asked if the user wanted to redownload the link to the schematisation again because this dialog is confusing. Now the link will always be downloaded. The downstream downloading of the schematisation is unchanged. At the moment there is no mechanism to fully check if a schematisation is already there so redownloading is the safest route. Once schematisations are natively in Rana we could consider putting effort in doing proper duplicate checking to prevent redownloading.