### PR TITLE
Remove pagination buttons in template selector

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ History
 - Prevent locking of layers based on gpkg metadata (nens/rana#3942)
 - Replace layers that are already opened instead of opening duplicates (nens/rana#3890)
 - Fix returning to FilesBrowser after delete via FileView
-- Remove pagination buttons in template selecotr (nens/rana#3849)
+- Remove pagination buttons in template selector (nens/rana#3849)
 
 
 1.2.9 (2026-03-30)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,8 +8,9 @@ History
 - Group vector layers under filename (nens/rana#3889)
 - Add create_debug_results field to simulation wizard simulation output settings (nens/rana#3857)
 - Prevent locking of layers based on gpkg metadata (nens/rana#3942)
-- Replace layers that are already opened instead of opening duplicates (nens/#rana#3890)
+- Replace layers that are already opened instead of opening duplicates (nens/rana#3890)
 - Fix returning to FilesBrowser after delete via FileView
+- Remove pagination buttons in template selecotr (nens/rana#3849)
 
 
 1.2.9 (2026-03-30)

--- a/rana_qgis_plugin/simulation/model_selection.py
+++ b/rana_qgis_plugin/simulation/model_selection.py
@@ -23,7 +23,6 @@ uicls, basecls = uic.loadUiType(
 
 logger = logging.getLogger(__name__)
 
-TABLE_LIMIT = 10
 NAME_COLUMN_IDX = 1
 
 
@@ -69,8 +68,6 @@ class ModelSelectionDialog(uicls, basecls):
         tc = ThreediCalls(self.threedi_api)
         self.current_model = tc.fetch_3di_model(self.model_pk)
         self.templates_model.clear()
-        self.templates_page_sbox.setMaximum(1)
-        self.templates_page_sbox.setSuffix(" / 1")
         self.fetch_simulation_templates()
         if self.templates_model.rowCount() > 0:
             row_idx = self.templates_model.index(0, 0)
@@ -87,14 +84,6 @@ class ModelSelectionDialog(uicls, basecls):
             self.pb_load.setEnabled(True)
         else:
             self.pb_load.setDisabled(True)
-
-    def move_templates_backward(self):
-        """Moving to the templates previous results page."""
-        self.templates_page_sbox.setValue(self.page_sbox.value() - 1)
-
-    def move_templates_forward(self):
-        """Moving to the templates next results page."""
-        self.templates_page_sbox.setValue(self.page_sbox.value() + 1)
 
     def populate_organisations(self):
         """Populating organisations list inside combo box."""
@@ -133,15 +122,11 @@ class ModelSelectionDialog(uicls, basecls):
         """Fetching simulation templates list."""
         try:
             tc = ThreediCalls(self.threedi_api)
-            offset = (self.templates_page_sbox.value() - 1) * TABLE_LIMIT
             selected_model = self.current_model
             model_pk = selected_model.id
-            templates, templates_count = tc.fetch_simulation_templates_with_count(
-                model_pk, limit=TABLE_LIMIT, offset=offset
+            templates = tc.fetch_simulation_templates(
+                simulation__threedimodel__id=model_pk
             )
-            pages_nr = ceil(templates_count / TABLE_LIMIT) or 1
-            self.templates_page_sbox.setMaximum(pages_nr)
-            self.templates_page_sbox.setSuffix(f" / {pages_nr}")
             self.templates_model.clear()
             header = ["Template ID", "Template name", "Creation date"]
             self.templates_model.setHorizontalHeaderLabels(header)

--- a/rana_qgis_plugin/simulation/simulation_wizard/model_selection.ui
+++ b/rana_qgis_plugin/simulation/simulation_wizard/model_selection.ui
@@ -137,122 +137,6 @@
           </property>
          </spacer>
         </item>
-        <item>
-         <widget class="QPushButton" name="pb_templates_prev_page">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <family>Segoe UI</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="layoutDirection">
-           <enum>Qt::LeftToRight</enum>
-          </property>
-          <property name="text">
-           <string>&lt;</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="templates_page_sbox">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>60</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <family>Segoe UI</family>
-           </font>
-          </property>
-          <property name="focusPolicy">
-           <enum>Qt::StrongFocus</enum>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">QSpinBox {background-color: white;}</string>
-          </property>
-          <property name="frame">
-           <bool>false</bool>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::NoButtons</enum>
-          </property>
-          <property name="suffix">
-           <string> / 1</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pb_templates_next_page">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <family>Segoe UI</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>&gt;</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item row="7" column="0">
@@ -365,9 +249,6 @@
  <tabstops>
   <tabstop>refresh_btn</tabstop>
   <tabstop>templates_tv</tabstop>
-  <tabstop>pb_templates_prev_page</tabstop>
-  <tabstop>templates_page_sbox</tabstop>
-  <tabstop>pb_templates_next_page</tabstop>
   <tabstop>organisations_box</tabstop>
   <tabstop>pb_cancel_load</tabstop>
   <tabstop>pb_load</tabstop>


### PR DESCRIPTION
Pagination buttons in the `ModelSelectionDialog` were not connected to any actions. I removed the buttons (after a discussion with Jonas) because the amount of templates doesn't seem to be a massive issue. @benvanbasten-ns just want to double check if you're ok with this.