### PR TITLE
Refactor: Generalize column auto-resize for FilesBrowser, introduce ContentAwareTreeView (#3874)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ History
 - Prevent locking of layers based on gpkg metadata (nens/rana#3942)
 - Replace layers that are already opened instead of opening duplicates (nens/#rana#3890)
 - Fix returning to FilesBrowser after delete via FileView
+- Improve FilesBrowser column resizing for long filenames (nens/rana#3874)
 
 
 1.2.9 (2026-03-30)

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -19,7 +19,6 @@ from qgis.PyQt.QtWidgets import (
     QLineEdit,
     QMenu,
     QPushButton,
-    QTreeView,
     QVBoxLayout,
     QWidget,
 )
@@ -39,6 +38,7 @@ from rana_qgis_plugin.widgets.utils_file_action import (
     get_file_actions_for_data_type,
 )
 from rana_qgis_plugin.widgets.utils_icons import get_icon_from_theme
+from rana_qgis_plugin.widgets.utils_view import ContentAwareTreeView
 
 # allow for using specific data just for sorting
 SORT_ROLE = Qt.ItemDataRole.UserRole + 1
@@ -107,7 +107,7 @@ class FilesBrowser(QWidget):
         self.fetch_and_populate(project)
 
     def setup_ui(self):
-        self.files_tv = QTreeView()
+        self.files_tv = ContentAwareTreeView()
         self.files_tv.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.files_tv.customContextMenuRequested.connect(self.menu_requested)
         self.files_model = FileBrowserModel()
@@ -279,9 +279,7 @@ class FilesBrowser(QWidget):
         self.files_tv.sortByColumn(sort_column, sort_order)
         self.files_tv.setSortingEnabled(True)
 
-        for i in range(len(header)):
-            self.files_tv.resizeColumnToContents(i)
-        self.files_tv.setColumnWidth(0, 300)
+        self.files_tv.resize_columns_aware_of_collapsed_items()
 
 
 class CreateFolderDialog(QDialog):

--- a/rana_qgis_plugin/widgets/publication_view.py
+++ b/rana_qgis_plugin/widgets/publication_view.py
@@ -60,6 +60,7 @@ from rana_qgis_plugin.widgets.utils_file_action import (
 )
 from rana_qgis_plugin.widgets.utils_icons import get_icon_from_theme, get_icon_label
 from rana_qgis_plugin.widgets.utils_qviews import update_width_with_wrapping
+from rana_qgis_plugin.widgets.utils_view import ContentAwareTreeView
 
 
 class MapItemType(Enum):
@@ -148,60 +149,6 @@ class LayerItemData(MapItemData):
             FileAction.SAVE_RASTER_STYLING in self.supported_actions
             or FileAction.SAVE_VECTOR_STYLING in self.supported_actions
         )
-
-
-class PublicationMapsTreeView(QTreeView):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-    def resize_columns_aware_of_collapsed_items(self):
-        """
-        Resize columns to fit their contents, including collapsed items.
-        """
-        # Save current collapsed status
-        expanded_states = {}
-        for row in range(self.model().rowCount()):
-            self._save_expanded_states(self.model().index(row, 0), expanded_states)
-        # Temporarily expand all items
-        for row in range(self.model().rowCount()):
-            self._expand_all_items(self.model().index(row, 0))
-        # Resize columns to fit *all items*, including collapsed ones
-        for col in range(self.model().columnCount()):
-            self.resizeColumnToContents(col)
-        # Restore the original collapsed state
-        for row in range(self.model().rowCount()):
-            self._restore_expanded_states(self.model().index(row, 0), expanded_states)
-
-    def _save_expanded_states(self, index, expanded_states):
-        """
-        Recursively save the expanded/collapsed state of all items.
-        """
-        if not index.isValid():
-            return
-        expanded_states[index] = self.isExpanded(index)
-        for row in range(index.model().rowCount(index)):
-            self._save_expanded_states(index.child(row, 0), expanded_states)
-
-    def _expand_all_items(self, index):
-        """
-        Recursively expand all items in the tree view.
-        """
-        if not index.isValid():
-            return
-        self.setExpanded(index, True)
-        for row in range(index.model().rowCount(index)):
-            self._expand_all_items(index.child(row, 0))
-
-    def _restore_expanded_states(self, index, expanded_states):
-        """
-        Recursively restore the expanded/collapsed state of items.
-        """
-        if not index.isValid():
-            return
-        if index in expanded_states:
-            self.setExpanded(index, expanded_states[index])
-        for row in range(index.model().rowCount(index)):
-            self._restore_expanded_states(index.child(row, 0), expanded_states)
 
 
 class MapCollector:
@@ -315,7 +262,7 @@ class PublicationView(QWidget):
         )
 
         self.maps_model = QStandardItemModel()
-        self.maps_tv = PublicationMapsTreeView()
+        self.maps_tv = ContentAwareTreeView()
         self.maps_tv.setEditTriggers(QTreeView.NoEditTriggers)
         self.maps_tv.setModel(self.maps_model)
         self.maps_tv.setUniformRowHeights(True)

--- a/rana_qgis_plugin/widgets/utils_view.py
+++ b/rana_qgis_plugin/widgets/utils_view.py
@@ -1,0 +1,64 @@
+from qgis.PyQt.QtWidgets import QTreeView
+
+
+class ContentAwareTreeView(QTreeView):
+    """
+    A QTreeView that intelligently resizes columns to fit their content,
+    even accounting for collapsed items in hierarchical views.
+    Useful for displaying long filenames or text without truncation.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def resize_columns_aware_of_collapsed_items(self):
+        """
+        Resize columns to fit their contents, including collapsed items.
+
+        This method temporarily expands all items to measure their content width,
+        resizes the columns accordingly, then restores the original collapsed state.
+        """
+        # Save current collapsed status
+        expanded_states = {}
+        for row in range(self.model().rowCount()):
+            self._save_expanded_states(self.model().index(row, 0), expanded_states)
+        # Temporarily expand all items
+        for row in range(self.model().rowCount()):
+            self._expand_all_items(self.model().index(row, 0))
+        # Resize columns to fit *all items*, including collapsed ones
+        for col in range(self.model().columnCount()):
+            self.resizeColumnToContents(col)
+        # Restore the original collapsed state
+        for row in range(self.model().rowCount()):
+            self._restore_expanded_states(self.model().index(row, 0), expanded_states)
+
+    def _save_expanded_states(self, index, expanded_states):
+        """
+        Recursively save the expanded/collapsed state of all items.
+        """
+        if not index.isValid():
+            return
+        expanded_states[index] = self.isExpanded(index)
+        for row in range(index.model().rowCount(index)):
+            self._save_expanded_states(index.child(row, 0), expanded_states)
+
+    def _expand_all_items(self, index):
+        """
+        Recursively expand all items in the tree view.
+        """
+        if not index.isValid():
+            return
+        self.setExpanded(index, True)
+        for row in range(index.model().rowCount(index)):
+            self._expand_all_items(index.child(row, 0))
+
+    def _restore_expanded_states(self, index, expanded_states):
+        """
+        Recursively restore the expanded/collapsed state of items.
+        """
+        if not index.isValid():
+            return
+        if index in expanded_states:
+            self.setExpanded(index, expanded_states[index])
+        for row in range(index.model().rowCount(index)):
+            self._restore_expanded_states(index.child(row, 0), expanded_states)


### PR DESCRIPTION
## Summary

This PR addresses issue #3874 by extracting content-aware column resizing logic into a new ContentAwareTreeView widget. This generalizes the resizing logic originally in PublicationMapsTreeView so it can be reused in FilesBrowser and other treeviews that display long filenames.

- Introduces rana_qgis_plugin/widgets/utils_view.py with ContentAwareTreeView
- Updates FilesBrowser to use ContentAwareTreeView and new resize_content_aware_columns method
- Updates PublicationMapsTreeView to use the new widget directly
- Ensures consistent display of long filenames with fewer manual workarounds
- All pre-commit checks, unit and e2e tests pass

