### PR TITLE
Fix file rename via context menu crash

### DIFF
--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -211,7 +211,6 @@ class FilesBrowser(QWidget):
         delegate = self.files_tv.itemDelegate()
 
         def on_close_editor(editor, hint):
-            delegate.closeEditor.disconnect(on_close_editor)
             if hint == QAbstractItemDelegate.EndEditHint.NoHint:
                 # editing was cancelled (Escape)
                 return
@@ -221,7 +220,9 @@ class FilesBrowser(QWidget):
                     selected_item, new_name
                 )
 
-        delegate.closeEditor.connect(on_close_editor)
+        delegate.closeEditor.connect(
+            on_close_editor, Qt.ConnectionType.SingleShotConnection
+        )
         self.files_tv.setCurrentIndex(name_index)
         self.files_tv.edit(name_index)
 

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -211,6 +211,7 @@ class FilesBrowser(QWidget):
         delegate = self.files_tv.itemDelegate()
 
         def on_close_editor(editor, hint):
+            delegate.closeEditor.disconnect(on_close_editor)
             if hint == QAbstractItemDelegate.EndEditHint.NoHint:
                 # editing was cancelled (Escape)
                 return
@@ -220,9 +221,7 @@ class FilesBrowser(QWidget):
                     selected_item, new_name
                 )
 
-        delegate.closeEditor.connect(
-            on_close_editor, Qt.ConnectionType.SingleShotConnection
-        )
+        delegate.closeEditor.connect(on_close_editor)
         self.files_tv.setCurrentIndex(name_index)
         self.files_tv.edit(name_index)
 

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -100,6 +100,7 @@ class FilesBrowser(QWidget):
         self.communication = communication
         self.selected_item = None
         self.file_signals = file_signals
+        self._pending_close_editor_handler = None
         self.setup_ui()
 
     def update_project(self, project: dict):
@@ -210,8 +211,14 @@ class FilesBrowser(QWidget):
         original_name = name_item.text()
         delegate = self.files_tv.itemDelegate()
 
+        # Disconnect any stale handler from a previous rename
+        if self._pending_close_editor_handler is not None:
+            delegate.closeEditor.disconnect(self._pending_close_editor_handler)
+            self._pending_close_editor_handler = None
+
         def on_close_editor(editor, hint):
             delegate.closeEditor.disconnect(on_close_editor)
+            self._pending_close_editor_handler = None
             if hint == QAbstractItemDelegate.EndEditHint.NoHint:
                 # editing was cancelled (Escape)
                 return
@@ -221,6 +228,7 @@ class FilesBrowser(QWidget):
                     selected_item, new_name
                 )
 
+        self._pending_close_editor_handler = on_close_editor
         delegate.closeEditor.connect(on_close_editor)
         self.files_tv.setCurrentIndex(name_index)
         self.files_tv.edit(name_index)

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -12,6 +12,7 @@ from qgis.PyQt.QtGui import (
     QStandardItemModel,
 )
 from qgis.PyQt.QtWidgets import (
+    QAbstractItemDelegate,
     QDialog,
     QDialogButtonBox,
     QGridLayout,
@@ -195,24 +196,34 @@ class FilesBrowser(QWidget):
         menu.popup(self.files_tv.viewport().mapToGlobal(pos))
 
     def edit_file_name(self, index: QModelIndex, selected_item: dict):
-        self.files_model.itemFromIndex(index).setFlags(
-            Qt.ItemFlag.ItemIsEditable
-            | Qt.ItemFlag.ItemIsEnabled
-            | Qt.ItemFlag.ItemIsSelectable
-        )
+        """Start in-place editing of the filename for the given item.
 
-        def handle_data_changed(topLeft, bottomRight, roles):
-            if topLeft == index:  # Only handle the specific item we're editing
-                new_name = self.files_model.itemFromIndex(topLeft).text()
-                signal = self.file_signals.get_signal(FileAction.RENAME)
-                signal.emit(selected_item, new_name)
-                self.files_model.dataChanged.disconnect(handle_data_changed)
+        Opens the inline editor on the filename column.  When the editor
+        closes with a commit, emits the rename signal with the new name.
+        If the name is unchanged the signal is not emitted.
+        """
+        name_index = index.sibling(index.row(), 0)
+        name_item = self.files_model.itemFromIndex(name_index)
+        if name_item is None:
+            return
 
-        # Connect to dataChanged signal
-        self.files_model.dataChanged.connect(handle_data_changed)
+        original_name = name_item.text()
+        delegate = self.files_tv.itemDelegate()
 
-        # Enter editing mode
-        self.files_tv.edit(index)
+        def on_close_editor(editor, hint):
+            delegate.closeEditor.disconnect(on_close_editor)
+            if hint == QAbstractItemDelegate.EndEditHint.NoHint:
+                # editing was cancelled (Escape)
+                return
+            new_name = editor.text().strip()
+            if new_name and new_name != original_name:
+                self.file_signals.get_signal(FileAction.RENAME).emit(
+                    selected_item, new_name
+                )
+
+        delegate.closeEditor.connect(on_close_editor)
+        self.files_tv.setCurrentIndex(name_index)
+        self.files_tv.edit(name_index)
 
     def select_file_or_directory(self, index: QModelIndex):
         self.busy.emit()


### PR DESCRIPTION
Closes #361

## Summary
- Implements the `edit_file_name` TODO in `files_browser.py` for renaming files via the context menu
- Fixes a crash that occurred when modifying the name: the previous approach used `itemChanged`/`dataChanged` which accessed the `QStandardItem` after `fetch_and_populate` had cleared the model, causing a crash on the deleted C++ object

## What changed
Uses `delegate.closeEditor` instead of `itemChanged`/`dataChanged` to capture the new name. The editor widget is still alive when `closeEditor` fires, so the new name is read safely from `editor.text()` before the model is touched. Escape (hint `NoHint`) cancels without emitting the rename signal.