### PR TITLE
Warn users about unsaved changes before uploading revision

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 1.2.10 (unreleased)
 -------------------
 
+- Warn users about unsaved changes when uploading a revision (nens/rana#3651)
 - Group vector layers under filename (nens/rana#3889)
 - Add create_debug_results field to simulation wizard simulation output settings (nens/rana#3857)
 - Prevent locking of layers based on gpkg metadata (nens/rana#3942)

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 
-from qgis.core import QgsSettings
+from qgis.core import QgsSettings, QgsProject
 from qgis.PyQt.QtCore import (
     QObject,
     QSettings,
@@ -39,10 +39,12 @@ from rana_qgis_plugin.simulation.utils import (
 )
 from rana_qgis_plugin.simulation.workers import SchematisationUploadProgressWorker
 from rana_qgis_plugin.utils import (
+    get_editable_layers_for_file,
     get_local_file_path,
     get_threedi_api,
     get_threedi_organisations,
     get_threedi_schematisation_simulation_results_folder,
+    save_layer_changes,
 )
 from rana_qgis_plugin.utils_api import (
     add_threedi_schematisation,
@@ -1051,6 +1053,51 @@ class Loader(QObject):
 
         schematisation_filepath = local_schematisation.schematisation_db_filepath
 
+        # Check for unsaved changes in layers
+        editable_layer_ids = []
+        for layer in get_editable_layers_for_file(schematisation_filepath):
+            editable_layer_ids.append(layer.id())
+
+        if editable_layer_ids:
+            choice = self.communication.custom_ask(
+                self.parent(),
+                "Unsaved Changes Detected",
+                "There are unsaved changes in the revision layers. What would you like to do?",
+                "Save Changes",
+                "Discard Changes",
+                "Cancel Upload",
+            )
+
+            if choice == "Cancel Upload":
+                self.schematisation_upload_cancelled.emit()
+                return
+
+            if choice == "Save Changes":
+                # Look up layers again (by ID) to ensure we have current references
+                project = QgsProject.instance()
+                for layer_id in editable_layer_ids:
+                    layer = project.mapLayers().get(layer_id)
+                    if layer is None:
+                        self.communication.show_error(
+                            f"Layer with ID {layer_id} is no longer available"
+                        )
+                        self.schematisation_upload_cancelled.emit()
+                        return
+
+                    success, error_msg = save_layer_changes(layer)
+                    if not success:
+                        self.communication.show_error(
+                            f"Failed to save changes in layer '{layer.name()}':\n{error_msg}"
+                        )
+                        self.schematisation_upload_cancelled.emit()
+                        return
+                self.communication.bar_info("Layer changes saved successfully")
+            else:  # choice == "Discard Changes"
+                # Keep edits in memory but continue with upload
+                self.communication.bar_info(
+                    "Unsaved changes will be kept in memory. Only file contents will be uploaded."
+                )
+
         schema_gpkg_loaded = is_loaded_in_schematisation_editor(schematisation_filepath)
         if schema_gpkg_loaded is False:
             question = "Warning: the revision you are about to upload is not loaded in the Rana Schematisation Editor. Do you want to continue?"
@@ -1104,12 +1151,13 @@ class Loader(QObject):
                 new_upload,
             )
             upload_worker.signals.create_model_requested.connect(
-                lambda revision_id,
-                inherit_from_previous_revision: self.start_model_tracker_process(
-                    project,
-                    schematisation.to_dict(),
-                    revision_id,
-                    inherit_from_previous_revision,
+                lambda revision_id, inherit_from_previous_revision: (
+                    self.start_model_tracker_process(
+                        project,
+                        schematisation.to_dict(),
+                        revision_id,
+                        inherit_from_previous_revision,
+                    )
                 )
             )
             upload_worker.signals.thread_finished.connect(

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 
-from qgis.core import QgsSettings, QgsProject
+from qgis.core import QgsProject, QgsSettings
 from qgis.PyQt.QtCore import (
     QObject,
     QSettings,

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -1054,11 +1054,11 @@ class Loader(QObject):
         schematisation_filepath = local_schematisation.schematisation_db_filepath
 
         # Check for unsaved changes in layers
-        editable_layer_ids = []
+        editable_layers = {}  # {layer_id: layer_name}
         for layer in get_editable_layers_for_file(schematisation_filepath):
-            editable_layer_ids.append(layer.id())
+            editable_layers[layer.id()] = layer.name()
 
-        if editable_layer_ids:
+        if editable_layers:
             choice = self.communication.custom_ask(
                 self.parent(),
                 "Unsaved Changes Detected",
@@ -1074,12 +1074,12 @@ class Loader(QObject):
 
             if choice == "Save Changes":
                 # Look up layers again (by ID) to ensure we have current references
-                project = QgsProject.instance()
-                for layer_id in editable_layer_ids:
-                    layer = project.mapLayers().get(layer_id)
+                qgs_project = QgsProject.instance()
+                for layer_id, layer_name in editable_layers.items():
+                    layer = qgs_project.mapLayers().get(layer_id)
                     if layer is None:
                         self.communication.show_error(
-                            f"Layer with ID {layer_id} is no longer available"
+                            f"Layer '{layer_name}' is no longer available in the project"
                         )
                         self.schematisation_upload_cancelled.emit()
                         return

--- a/rana_qgis_plugin/utils.py
+++ b/rana_qgis_plugin/utils.py
@@ -299,3 +299,78 @@ def get_file_icon_name(data_type: str) -> str:
         "sqlite": "mIconDbSchema.svg",
     }
     return icon_map.get(data_type, "mIconFile.svg")
+
+
+def get_editable_layers_for_file(file_path: str) -> list[QgsVectorLayer]:
+    """Get vector layers in edit mode with unsaved changes for a specific file.
+
+    Args:
+        file_path: Path to the geopackage file (e.g., schematisation_db_filepath)
+
+    Returns:
+        List of QgsVectorLayer objects that:
+        - Are in edit mode (isEditable() == True)
+        - Have unsaved modifications (isModified() == True)
+        - Belong to the specified file (file_path in layer.source())
+    """
+    editable_layers = []
+    project = QgsProject.instance()
+    normalized_file_path = os.path.normpath(file_path)
+
+    for layer in project.mapLayers().values():
+        if not hasattr(layer, "isEditable"):
+            continue
+
+        # Double-check layer is editable and has modifications
+        if not layer.isEditable() or not layer.isModified():
+            continue
+
+        # Check if layer belongs to this file
+        if hasattr(layer, "source"):
+            normalized_source = os.path.normpath(layer.source())
+            if normalized_file_path in normalized_source:
+                editable_layers.append(layer)
+
+    return editable_layers
+
+
+def save_layer_changes(layer: QgsVectorLayer) -> tuple[bool, str | None]:
+    """Commit unsaved changes to a vector layer.
+
+    This function commits all pending changes. If the layer is in edit mode,
+    it will commit and exit. If not, it returns an error.
+
+    Args:
+        layer: QgsVectorLayer object to commit changes for
+
+    Returns:
+        Tuple of (success: bool, error_message: str | None)
+        - (True, None) if commit was successful
+        - (False, error_message) if commit failed or layer not editable
+    """
+    # If layer is not editable, it means changes were already committed
+    # or the layer state changed. In either case, we can't proceed.
+    if not layer.isEditable():
+        # Check if there are any pending modifications
+        if layer.isModified():
+            return False, (
+                f"Layer '{layer.name()}' has modifications but is not in edit mode. "
+                "Cannot save changes."
+            )
+        # No modifications, so nothing to save
+        return True, None
+
+    try:
+        # Commit changes (this also exits edit mode)
+        success = layer.commitChanges()
+
+        if success:
+            return True, None
+
+        # If commit failed, collect error messages
+        errors = layer.commitErrors()
+        error_message = "\n".join(errors) if errors else "Unknown commit error"
+        return False, error_message
+    except Exception as e:
+        # Catch any exceptions from commitChanges (e.g., database errors)
+        return False, f"Error committing changes: {str(e)}"

--- a/rana_qgis_plugin/utils.py
+++ b/rana_qgis_plugin/utils.py
@@ -315,7 +315,7 @@ def get_editable_layers_for_file(file_path: str) -> list[QgsVectorLayer]:
     """
     editable_layers = []
     project = QgsProject.instance()
-    normalized_file_path = os.path.normpath(file_path)
+    normalized_file_path = str(Path(file_path).resolve())
 
     for layer in project.mapLayers().values():
         if not hasattr(layer, "isEditable"):
@@ -327,7 +327,7 @@ def get_editable_layers_for_file(file_path: str) -> list[QgsVectorLayer]:
 
         # Check if layer belongs to this file
         if hasattr(layer, "source"):
-            normalized_source = os.path.normpath(layer.source())
+            normalized_source = str(Path(layer.source()).resolve())
             if normalized_file_path in normalized_source:
                 editable_layers.append(layer)
 


### PR DESCRIPTION
## Summary

Warn users about unsaved changes in vector layers before uploading a revision. Users can choose to save edits, discard them, or cancel the upload.

## What was added

- Two utility functions in `rana_qgis_plugin/utils.py`:
  - `get_editable_layers_for_file(file_path)` - Detects vector layers with unsaved changes
  - `save_layer_changes(layer)` - Commits unsaved changes to a layer

- Warning dialog in `save_revision()` method with three options: Save Changes, Discard Changes, or Cancel Upload

## Related issue

Closes nens/rana#3651