### PR TITLE
Fix schematisation upgrade failure crashing download

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ History
 - Fix returning to FilesBrowser after delete via FileView
 - Remove pagination buttons in template selector (nens/rana#3849)
 - Disable UI elements when no 3Di authorization (nens/rana#3758)
+- Fix warnins upon logout (nens/rana#3813)
 
 
 1.2.10 (2026-04-14)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,7 +23,7 @@ History
 - Remove pagination buttons in template selector (nens/rana#3849)
 - Disable UI elements when no 3Di authorization (nens/rana#3758)
 - Remove usage of deprecated raster/vector specific styling endpoints (nens/rana-qgis-plugin#320)
-- Fix warnins upon logout (nens/rana#3813)
+- Fix warnings upon logout (nens/rana#3813)
 
 
 1.2.10 (2026-04-14)

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -129,12 +129,12 @@ class RanaQgisPlugin:
 
     def logout(self):
         self.communication.clear_message_bar()
+        self.rana_browser.reset()
         remove_authcfg(self.communication)
         remove_3di_auth(self.communication)
         set_tenant_id("")
         self.add_rana_menu(False)
         self.communication.bar_info("You have been logged out.")
-        self.rana_browser.reset()
         if self.dock_widget:
             self.dock_widget.close()
 

--- a/rana_qgis_plugin/workers/download.py
+++ b/rana_qgis_plugin/workers/download.py
@@ -211,8 +211,6 @@ class BaseDownloader:
             signals.finished.emit()
         except requests.exceptions.RequestException as e:
             signals.failed.emit(f"Failed to download file: {str(e)}")
-        except SchematisationUpgradeError as e:
-            signals.failed.emit(e)
         except Exception as e:
             # failure to retrieve url will raise a ValueError or FetchError and end up here
             signals.failed.emit(f"An error occurred: {str(e)}")
@@ -300,19 +298,27 @@ class SchematisationDownloader(BaseDownloader):
             f"Expected exactly one file in {self.download_context.local_dir}, found {len(extracted_files)}"
         )
         schematisation_file = extracted_files[0]
-        # TODO: handle existing as early as possible!! - check if .gpkg version exists here?
-        # Upgrade schematisation to latest
-        upgaded_schematisation_path = self._upgrade_schematisation(schematisation_file)
-        if upgaded_schematisation_path:
-            schematisation_file = upgaded_schematisation_path
-            # Include revision number in file name
-            rev_nr = self.revision_number
-            file_name_with_rev = (
-                f"{schematisation_file.stem} (rev{rev_nr}){schematisation_file.suffix}"
+        # Upgrade schematisation to latest; on failure warn and continue with original gpkg
+        try:
+            upgraded_schematisation_path = self._upgrade_schematisation(
+                schematisation_file
             )
-            path_with_rev = schematisation_file.parent.joinpath(file_name_with_rev)
-            schematisation_file.rename(path_with_rev)
-            self._downloaded_file_path = path_with_rev
+            if upgraded_schematisation_path:
+                schematisation_file = upgraded_schematisation_path
+        except SchematisationUpgradeError as e:
+            if self.warning_signal is not None:
+                # not adding actual schema version here because import failure is one of the triggers of this error
+                self.warning_signal.emit(
+                    f"Schematisation upgrade failed, continuing with original schematisation version: {e}"
+                )
+        # Include revision number in file name
+        rev_nr = self.revision_number
+        file_name_with_rev = (
+            f"{schematisation_file.stem} (rev{rev_nr}){schematisation_file.suffix}"
+        )
+        path_with_rev = schematisation_file.parent.joinpath(file_name_with_rev)
+        schematisation_file.rename(path_with_rev)
+        self._downloaded_file_path = path_with_rev
 
     def _upgrade_schematisation(self, schematisation_filepath: Path) -> Optional[Path]:
         # Assert signals are set properly


### PR DESCRIPTION
## Summary

- When `SchematisationUpgradeError` is raised during `postprocess()`, warn the user and continue with the original gpkg instead of aborting the entire download
- Fix `TypeError` where `SchematisationUpgradeError` was being passed directly to `FileDownloadWorkerSignals.failed[str].emit()` in `BaseDownloader.download_file()` instead of a string
- `_downloaded_file_path` is now always set after postprocessing, regardless of whether the upgrade succeeded