### PR TITLE
Rescale range for physical_quantity.qml 

### DIFF
--- a/rana_qgis_plugin/utils/qgis.py
+++ b/rana_qgis_plugin/utils/qgis.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from xml.etree import ElementTree as ET
 
 from qgis.core import (
     Qgis,
@@ -70,3 +71,74 @@ def convert_vectorfile_to_geopackage(
     )
 
     return gpkg_path
+
+
+def rescale_qml_ranges(qml_string: str, new_min: float, new_max: float) -> str | None:
+    """Rescale QML raster style to a new data range.
+
+    Updates classificationMin/Max, shader ranges, and proportionally rescales color
+    stop values. Returns None if no changes needed, otherwise returns modified QML.
+    """
+    # Validate input qml; skip rescaling in case of any problems
+    try:
+        root = ET.fromstring(qml_string)
+    except ET.ParseError:
+        return None
+    raster_renderer = root.find(".//rasterrenderer")
+    if raster_renderer is None:
+        return None
+    try:
+        current_min = float(raster_renderer.get("classificationMin", "0"))
+        current_max = float(raster_renderer.get("classificationMax", "1"))
+    except (ValueError, TypeError):
+        return None
+    # Validate range; skip rescaling if degenerate
+    if current_min == current_max:
+        return None
+    # Return if no changes are needed
+    if current_min == new_min and current_max == new_max:
+        return None
+
+    # Update rasterrenderer attributes
+    raster_renderer.set("classificationMin", str(new_min))
+    raster_renderer.set("classificationMax", str(new_max))
+
+    # Find and update the colorrampshader element
+    shader = raster_renderer.find(".//colorrampshader")
+    if shader is None:
+        return ET.tostring(root, encoding="unicode")
+    shader.set("minimumValue", str(new_min))
+    shader.set("maximumValue", str(new_max))
+
+    # Rescale color stop values proportionally
+    for item in shader.findall("item"):
+        try:
+            old_value = float(item.get("value", "0"))
+        except (ValueError, TypeError):
+            continue
+        t = (old_value - current_min) / (current_max - current_min)
+        new_value = new_min + t * (new_max - new_min)
+        item.set("value", str(new_value))
+
+    return ET.tostring(root, encoding="unicode")
+
+
+def rescale_qml_file(file_path: Path, new_min: float, new_max: float) -> None:
+    """Rescale QML file ranges and save only if changed.
+
+    Args:
+        file_path: Path to the QML file
+        new_min: Target minimum data value
+        new_max: Target maximum data value
+    """
+    try:
+        content = file_path.read_text()
+    except (IOError, OSError):
+        return
+
+    rescaled = rescale_qml_ranges(content, new_min, new_max)
+    if rescaled is not None:
+        try:
+            file_path.write_text(rescaled)
+        except (IOError, OSError):
+            pass

--- a/rana_qgis_plugin/workers/download.py
+++ b/rana_qgis_plugin/workers/download.py
@@ -40,6 +40,7 @@ from rana_qgis_plugin.utils.generic import (
     get_threedi_api,
     split_scenario_extent,
 )
+from rana_qgis_plugin.utils.qgis import rescale_qml_file
 
 CHUNK_SIZE = 1024 * 1024  # 1 MB
 
@@ -246,7 +247,32 @@ class RanaDownloader(BaseDownloader):
         pq_path = self.download_context.local_dir / "physical_quantity.qml"
         if pq_path.exists():
             new_name = self.download_context.local_file_path.with_suffix(".qml").name
-            pq_path.rename(self.download_context.local_dir / new_name)
+            final_qml_path = self.download_context.local_dir / new_name
+            pq_path.rename(final_qml_path)
+
+            # Attempt to rescale the QML to match the actual raster data range
+            self._rescale_qml_to_raster_range(final_qml_path)
+
+    def _rescale_qml_to_raster_range(self, qml_path: Path) -> None:
+        """Rescale QML file to match actual raster data range from descriptor.
+
+        Gracefully skips rescaling if descriptor or range data is unavailable.
+        """
+        # Fetch the file descriptor to get the actual data range
+        descriptor = get_tenant_file_descriptor(self.file["descriptor_id"])
+        if descriptor is None:
+            return
+
+        # Extract min/max from descriptor metadata
+        meta = descriptor.get("meta") or {}
+        range_data = meta.get("range_type") or {}
+        new_min = range_data.get("min")
+        new_max = range_data.get("max")
+        if new_min is None or new_max is None:
+            return
+
+        # Attempt to rescale the QML file
+        rescale_qml_file(qml_path, float(new_min), float(new_max))
 
 
 class SchematisationDownloader(BaseDownloader):

--- a/tests/test_utils_qgis.py
+++ b/tests/test_utils_qgis.py
@@ -1,0 +1,62 @@
+from rana_qgis_plugin.utils.qgis import rescale_qml_ranges
+
+
+def make_test_qml(min_val: float, max_val: float, num_stops: int) -> str:
+    """Generate minimal test QML with rasterrenderer and colorrampshader.
+
+    Creates color stops evenly distributed across the range [min_val, max_val].
+    """
+    color_stops = []
+    for i in range(num_stops):
+        t = i / (num_stops - 1) if num_stops > 1 else 0
+        value = min_val + t * (max_val - min_val)
+        label = f"{value:.4f}"
+        color_stops.append(
+            f'          <item alpha="255" color="#ffffff" label="{label}" value="{value}"/>'
+        )
+
+    color_stops_str = "\n".join(color_stops)
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<qgis>
+  <pipe>
+    <rasterrenderer type="singlebandpseudocolor" band="1" classificationMin="{min_val}" classificationMax="{max_val}" opacity="1">
+      <rastershader>
+        <colorrampshader type="INTERPOLATED" minimumValue="{min_val}" maximumValue="{max_val}">
+{color_stops_str}
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+  </pipe>
+</qgis>"""
+
+
+class TestRescaleQmlRanges:
+    """Test QML range rescaling."""
+
+    def test_rescale_when_needed(self):
+        """Rescale from 0-1 to 0-1000."""
+        qml = make_test_qml(0.0, 1.0, 5)
+        rescaled = rescale_qml_ranges(qml, 0.0, 1000.0)
+
+        assert rescaled is not None
+        assert 'classificationMin="0.0"' in rescaled
+        assert 'classificationMax="1000.0"' in rescaled
+        assert 'minimumValue="0.0"' in rescaled
+        assert 'maximumValue="1000.0"' in rescaled
+
+        # Check that color stops are proportionally rescaled
+        # Original stops at 0, 0.25, 0.5, 0.75, 1.0
+        # Should rescale to 0, 250, 500, 750, 1000
+        assert 'value="0.0"' in rescaled
+        assert 'value="250.0"' in rescaled
+        assert 'value="500.0"' in rescaled
+        assert 'value="750.0"' in rescaled
+        assert 'value="1000.0"' in rescaled
+
+    def test_no_change_when_ranges_match(self):
+        """Return None when ranges already match."""
+        qml = make_test_qml(0.0, 1.0, 3)
+        rescaled = rescale_qml_ranges(qml, 0.0, 1.0)
+
+        assert rescaled is None


### PR DESCRIPTION
The `physical_quantity.qml` created by the BE has a fixed range from 0 to 1 so that there can be a single kind of style for every raster. The RDC uses the ranges in the file descriptor to update this range in the qml. 

I choose to modify the qml so the layer manager doesn't need to know where the qml came from and can just load it.