### PR TITLE
e2e test for logout and login

### DIFF
--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -1,5 +1,6 @@
 import os
 
+from qgis.core import QgsApplication, QgsAuthMethodConfig
 from qgis.PyQt.QtCore import Qt, QTimer
 from qgis.PyQt.QtGui import QImage
 from qgis.PyQt.QtTest import QTest
@@ -11,6 +12,9 @@ from e2e.test_utils import (
     images_equal,
     press_button_with_moderator,
 )
+from rana_qgis_plugin.auth import get_authcfg_id
+from rana_qgis_plugin.auth_3di import set_3di_auth
+from rana_qgis_plugin.constant import PLUGIN_NAME, RANA_SETTINGS_ENTRY
 from rana_qgis_plugin.utils.api import delete_tenant_project_file
 
 
@@ -21,6 +25,55 @@ def test_smoke(plugin, request):
     QTest.mouseClick(rana_tool_button, Qt.LeftButton)
     QTest.qWait(1000)
     assert plugin.rana_browser.projects_browser.projects_tv.model().rowCount() == 1
+
+
+def test_login_logout(plugin):
+    """Test login via toolbar click, then logout, then login again."""
+    # Step 1: Click toolbar button to trigger login
+    rana_tool_button = plugin.toolbar.widgetForAction(plugin.action)
+    QTest.mouseClick(rana_tool_button, Qt.LeftButton)
+    QTest.qWait(1000)
+
+    # Verify logged-in state
+    menu = plugin.iface.mainWindow().getPluginMenu(PLUGIN_NAME)
+    menu_texts = [action.text() for action in menu.actions()]
+    assert "Logout" in menu_texts
+    assert "test user" in menu_texts
+    assert plugin.dock_widget is not None
+    assert plugin.dock_widget.isVisible()
+
+    # Step 2: Trigger logout via menu action
+    logout_action = next(a for a in menu.actions() if a.text() == "Logout")
+    logout_action.trigger()
+    QTest.qWait(500)
+
+    # Verify logged-out state
+    menu_texts = [action.text() for action in menu.actions()]
+    assert "Logout" not in menu_texts
+    assert "test user" not in menu_texts
+    assert "Open Rana Panel" in menu_texts
+    assert not plugin.dock_widget.isVisible()
+    assert get_authcfg_id() is None
+
+    # Step 3: Re-insert auth configs and login again via toolbar click
+    auth_manager = QgsApplication.authManager()
+    authcfg = QgsAuthMethodConfig()
+    authcfg.setName(RANA_SETTINGS_ENTRY)
+    authcfg.setMethod("Basic")
+    authcfg.setConfig("username", "__key__")
+    authcfg.setConfig("password", os.getenv("RANA_PAK", "test_secret"))
+    assert authcfg.isValid()
+    auth_manager.storeAuthenticationConfig(authcfg)
+    set_3di_auth("test_api_key")
+
+    QTest.mouseClick(rana_tool_button, Qt.LeftButton)
+    QTest.qWait(1000)
+
+    # Verify logged-in state again
+    menu_texts = [action.text() for action in menu.actions()]
+    assert "Logout" in menu_texts
+    assert "test user" in menu_texts
+    assert plugin.dock_widget.isVisible()
 
 
 def test_upload(plugin, qtbot, request):

--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -44,7 +44,10 @@ def test_login_logout(plugin):
 
     # Step 2: Trigger logout via menu action
     logout_action = next(a for a in menu.actions() if a.text() == "Logout")
-    logout_action.trigger()
+    menu.popup(menu.mapToGlobal(menu.rect().topLeft()))
+    QTest.qWait(100)
+    action_rect = menu.actionGeometry(logout_action)
+    QTest.mouseClick(menu, Qt.LeftButton, pos=action_rect.center())
     QTest.qWait(500)
 
     # Verify logged-out state
@@ -66,7 +69,11 @@ def test_login_logout(plugin):
     auth_manager.storeAuthenticationConfig(authcfg)
     set_3di_auth("test_api_key")
 
-    QTest.mouseClick(rana_tool_button, Qt.LeftButton)
+    login_action = next(a for a in menu.actions() if a.text() == "Open Rana Panel")
+    menu.popup(menu.mapToGlobal(menu.rect().topLeft()))
+    QTest.qWait(100)
+    action_rect = menu.actionGeometry(login_action)
+    QTest.mouseClick(menu, Qt.LeftButton, pos=action_rect.center())
     QTest.qWait(1000)
 
     # Verify logged-in state again

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -179,6 +179,7 @@ class Loader(QObject):
         self.avatar_runner_pool.setMaxThreadCount(1)
 
         # For upload of schematisations
+        self.avatar_worker: QRunnable = None
         self.upload_thread_pool = QThreadPool()
         self.upload_thread_pool.setMaxThreadCount(1)
 
@@ -188,6 +189,11 @@ class Loader(QObject):
 
     def cleanup(self):
         self.persistent_scheduler.stop()
+        if self.avatar_runner_pool is not None:
+            if self.avatar_worker is not None:
+                self.avatar_worker.cancel()
+            self.avatar_runner_pool.clear()
+            self.avatar_runner_pool.waitForDone(500)  # short grace period (ms)
 
     def __del__(self):
         self.cleanup()

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -129,14 +129,17 @@ class RanaQgisPlugin:
 
     def logout(self):
         self.communication.clear_message_bar()
+        # reset browser and stop processes before actual logout
         self.rana_browser.reset()
+        if self.dock_widget:
+            self.dock_widget.close()
+        if self.loader:
+            self.loader.cleanup()
         remove_authcfg(self.communication)
         remove_3di_auth(self.communication)
         set_tenant_id("")
         self.add_rana_menu(False)
         self.communication.bar_info("You have been logged out.")
-        if self.dock_widget:
-            self.dock_widget.close()
 
     def set_tenant(self, start_tenant_id: str = None):
         if start_tenant_id is None:

--- a/rana_qgis_plugin/workers/avatars.py
+++ b/rana_qgis_plugin/workers/avatars.py
@@ -20,9 +20,15 @@ class AvatarWorker(QRunnable):
         self.communication = communication
         self.users = users
         self.signals = AvatarWorkerSignals()
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
 
     def run(self):
         for user in self.users:
+            if self._cancelled:
+                break
             new_avatar = get_avatar(
                 user, self.communication, create_from_initials=False
             )


### PR DESCRIPTION
- Added test
- Call `loader.cleanup` upon logout to stop any workers
- Extend `loader.cleanup` and `AvatarWorker` to also stop the avatar loading