### PR TITLE
Split new schematisation from scratch and new schematisation from gpgk

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,7 @@ History
 - Show user that created the last commit in de FileView next to the commit message (nens/rana#4169)
 - Optionally clear cache on close and remove downloaded results zip from cache (nens/rana#3975)
 - Remove results download folder on canceling download (nens/rana-qgis-plugin#323)
+- Split new schematisation from scratch and new schematisation from file functionality (nens/#rana4224)
 
 
 1.2.12 (2026-05-06)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ History
 - Show user that created the last commit in de FileView next to the commit message (nens/rana#4169)
 - Optionally clear cache on close and remove downloaded results zip from cache (nens/rana#3975)
 - Remove results download folder on canceling download (nens/rana-qgis-plugin#323)
-- Split new schematisation from scratch and new schematisation from file functionality (nens/#rana4224)
+- Split new schematisation from scratch and new schematisation from file functionality (nens/rana#4224)
 
 
 1.2.12 (2026-05-06)

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -43,6 +43,7 @@ from rana_qgis_plugin.simulation.utils import (
     resolve_schematisation_download_dir,
     resolve_schematisation_download_dir_auto,
 )
+from rana_qgis_plugin.simulation.utils_ui import get_filepath
 from rana_qgis_plugin.simulation.workers import SchematisationUploadProgressWorker
 from rana_qgis_plugin.utils.api import (
     ConflictError,
@@ -86,7 +87,11 @@ from rana_qgis_plugin.utils.settings import hcc_working_dir
 from rana_qgis_plugin.utils.time import convert_timestamp_str_to_local_time
 from rana_qgis_plugin.widgets.result_browser import ResultBrowser
 from rana_qgis_plugin.widgets.schematisation_browser import SchematisationBrowser
-from rana_qgis_plugin.widgets.schematisation_new_wizard import NewSchematisationWizard
+from rana_qgis_plugin.widgets.schematisation_new_wizard import (
+    NewSchematisationWizard,
+    UploadExistingSchematisationWizard,
+    get_paths_from_geopackage,
+)
 from rana_qgis_plugin.workers.avatars import (
     AvatarWorker,
 )
@@ -1541,38 +1546,32 @@ class Loader(QObject):
             )
         self.schematisation_import_finished.emit()
 
-    @pyqtSlot(dict, dict)
-    def upload_new_schematisation_to_rana(self, project, selected_item):
-        assert selected_item["type"] == "directory"
-        rana_path = selected_item["id"]
+    def _get_threedi_api_and_organisations(self):
+        """Fetch threedi API and available organisations for the current tenant.
+
+        Returns a tuple of (threedi_api, organisations) or None if setup fails.
+        """
         threedi_api = get_threedi_api()
         tenant_details = get_tenant_details(self.communication)
         if not tenant_details:
-            return
+            return None
         tc = ThreediCalls(threedi_api)
         allowed_org_ids = get_threedi_organisations(self.communication)
         organisations = {
             org.unique_id: org for org in tc.fetch_organisations(allowed_org_ids)
         }
-
         if len(organisations) == 0:
             self.communication.show_error(
                 "No 3Di organisations available for this Rana organisation; please make sure your API endpoint is configured."
             )
             self.schematisation_upload_failed.emit()
-            return
+            return None
+        return threedi_api, organisations
 
-        work_dir = QSettings().value("threedi/working_dir", "")
-        new_schematisation_wizard = NewSchematisationWizard(
-            threedi_api, work_dir, self.communication, organisations
-        )
-        response = new_schematisation_wizard.exec()
-        if response != QDialog.DialogCode.Accepted:
-            self.schematisation_upload_cancelled.emit()
-            return
-
-        local_schematisation = new_schematisation_wizard.new_local_schematisation
-        new_schematisation = new_schematisation_wizard.new_schematisation
+    def _finish_schematisation_upload(self, project, rana_path, wizard):
+        """Handle the post-wizard flow common to both schematisation upload slots."""
+        local_schematisation = wizard.new_local_schematisation
+        new_schematisation = wizard.new_schematisation
         if new_schematisation is None or local_schematisation is None:
             self.communication.bar_error("Schematisation creation failed")
             self.schematisation_upload_failed.emit()
@@ -1584,9 +1583,7 @@ class Loader(QObject):
                 "Revision creation failed; please create one manually later in the Rana browser"
             )
         else:
-            # Search GeoPackage database tables for attributes with file paths.
-            paths = new_schematisation_wizard.get_paths_from_geopackage(db_path)
-
+            paths = get_paths_from_geopackage(db_path)
             self.save_initial_revision(
                 project, new_schematisation, local_schematisation, paths
             )
@@ -1620,6 +1617,55 @@ class Loader(QObject):
             local_schematisation=local_schematisation.wip_revision,
             action=BuildOptionActions.CREATED,
         )
+
+    @pyqtSlot(dict, dict)
+    def upload_new_schematisation_to_rana(self, project, selected_item):
+        assert selected_item["type"] == "directory"
+        rana_path = selected_item["id"]
+        result = self._get_threedi_api_and_organisations()
+        if result is None:
+            return
+        threedi_api, organisations = result
+
+        work_dir = QSettings().value("threedi/working_dir", "")
+        wizard = NewSchematisationWizard(
+            threedi_api, work_dir, self.communication, organisations
+        )
+        response = wizard.exec()
+        if response != QDialog.DialogCode.Accepted:
+            self.schematisation_upload_cancelled.emit()
+            return
+        self._finish_schematisation_upload(project, rana_path, wizard)
+
+    @pyqtSlot(dict, dict)
+    def upload_existing_schematisation_to_rana(self, project, selected_item):
+        assert selected_item["type"] == "directory"
+        rana_path = selected_item["id"]
+
+        gpkg_filter = "GeoPackage/SQLite (*.gpkg *.GPKG *.sqlite *SQLITE)"
+        gpkg_path = get_filepath(
+            None,
+            dialog_title="Select Schematisation file",
+            extension_filter=gpkg_filter,
+        )
+        if gpkg_path is None:
+            self.schematisation_upload_cancelled.emit()
+            return
+
+        result = self._get_threedi_api_and_organisations()
+        if result is None:
+            return
+        threedi_api, organisations = result
+
+        work_dir = QSettings().value("threedi/working_dir", "")
+        wizard = UploadExistingSchematisationWizard(
+            threedi_api, work_dir, self.communication, organisations, gpkg_path
+        )
+        response = wizard.exec()
+        if response != QDialog.DialogCode.Accepted:
+            self.schematisation_upload_cancelled.emit()
+            return
+        self._finish_schematisation_upload(project, rana_path, wizard)
 
     @pyqtSlot(dict, dict)
     def save_revision(self, project, file):

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -1554,6 +1554,7 @@ class Loader(QObject):
         threedi_api = get_threedi_api()
         tenant_details = get_tenant_details(self.communication)
         if not tenant_details:
+            self.schematisation_upload_failed.emit()
             return None
         tc = ThreediCalls(threedi_api)
         allowed_org_ids = get_threedi_organisations(self.communication)

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -390,6 +390,12 @@ class RanaQgisPlugin:
             self.rana_browser.upload_new_schematisation_selected.connect(
                 self.loader.upload_new_schematisation_to_rana
             )
+            self.rana_browser.upload_existing_schematisation_selected.connect(
+                self.rana_browser.disable
+            )
+            self.rana_browser.upload_existing_schematisation_selected.connect(
+                self.loader.upload_existing_schematisation_to_rana
+            )
             self.rana_browser.import_schematisation_selected.connect(
                 self.rana_browser.disable
             )

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -156,7 +156,9 @@ class FilesBrowser(QWidget):
         btn_create_folder.clicked.connect(self.show_create_folder_dialog)
         self.btn_new_schematisation = QPushButton("New schematisation")
         self.btn_import_schematisation = QPushButton("Import schematisation")
-        self.btn_upload_existing_schematisation = QPushButton("Upload existing schematisation")
+        self.btn_upload_existing_schematisation = QPushButton(
+            "Upload existing schematisation"
+        )
         # Page 0: Normal mode buttons
         normal_page = QWidget()
         btn_layout = QVBoxLayout(normal_page)

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -13,7 +13,6 @@ from qgis.PyQt.QtWidgets import (
     QAbstractItemView,
     QDialog,
     QDialogButtonBox,
-    QGridLayout,
     QHBoxLayout,
     QHeaderView,
     QLabel,
@@ -157,13 +156,19 @@ class FilesBrowser(QWidget):
         btn_create_folder.clicked.connect(self.show_create_folder_dialog)
         self.btn_new_schematisation = QPushButton("New schematisation")
         self.btn_import_schematisation = QPushButton("Import schematisation")
+        self.btn_upload_existing_schematisation = QPushButton("Upload existing schematisation")
         # Page 0: Normal mode buttons
         normal_page = QWidget()
-        btn_layout = QGridLayout(normal_page)
-        btn_layout.addWidget(self.btn_upload, 0, 0)
-        btn_layout.addWidget(btn_create_folder, 0, 1)
-        btn_layout.addWidget(self.btn_new_schematisation, 1, 0)
-        btn_layout.addWidget(self.btn_import_schematisation, 1, 1)
+        btn_layout = QVBoxLayout(normal_page)
+        row1 = QHBoxLayout()
+        row1.addWidget(self.btn_upload)
+        row1.addWidget(btn_create_folder)
+        row2 = QHBoxLayout()
+        row2.addWidget(self.btn_new_schematisation)
+        row2.addWidget(self.btn_upload_existing_schematisation)
+        row2.addWidget(self.btn_import_schematisation)
+        btn_layout.addLayout(row1)
+        btn_layout.addLayout(row2)
         # Page 1: Select mode buttons
         select_page = QWidget()
         select_layout = QHBoxLayout(select_page)
@@ -192,6 +197,7 @@ class FilesBrowser(QWidget):
 
         self.btn_new_schematisation.setVisible(has_3di_authcfg())
         self.btn_import_schematisation.setVisible(has_3di_authcfg())
+        self.btn_upload_existing_schematisation.setVisible(has_3di_authcfg())
         # Connect checkbox state changes to update batch button states
         self.files_model.itemChanged.connect(self._update_batch_buttons)
 

--- a/rana_qgis_plugin/widgets/new_wizard_pages/name.py
+++ b/rana_qgis_plugin/widgets/new_wizard_pages/name.py
@@ -47,6 +47,31 @@ class SchematisationNamePage(QWizardPage):
     def isComplete(self):
         return bool(self.field("schematisation_name"))
 
+    @property
+    def name(self):
+        """Schematisation name as entered by the user."""
+        return self.field("schematisation_name")
+
+    @property
+    def description(self):
+        """Schematisation description as entered by the user."""
+        return self.field("schematisation_description")
+
+    @property
+    def tags(self):
+        """Schematisation tags as a list of stripped strings."""
+        raw = self.field("schematisation_tags")
+        if not raw:
+            return []
+        return [tag.strip() for tag in raw.split(",")]
+
+    @property
+    def owner(self):
+        """Unique ID of the selected organisation."""
+        if len(self.organisations) > 1:
+            return self.field("schematisation_organisation").unique_id
+        return list(self.organisations.values())[0].unique_id
+
 
 class SchematisationNameWidget(QWidget):
     """Widget for the Schematisation Name and tags page."""

--- a/rana_qgis_plugin/widgets/new_wizard_pages/name.py
+++ b/rana_qgis_plugin/widgets/new_wizard_pages/name.py
@@ -3,19 +3,15 @@ from functools import partial
 from qgis.PyQt.QtWidgets import (
     QComboBox,
     QGridLayout,
-    QHBoxLayout,
     QLabel,
     QLineEdit,
-    QRadioButton,
     QSizePolicy,
     QSpacerItem,
-    QToolButton,
     QWidget,
     QWizardPage,
 )
 
 from rana_qgis_plugin.simulation.utils_ui import (
-    get_filepath,
     read_3di_settings,
     save_3di_settings,
 )
@@ -35,14 +31,6 @@ class SchematisationNamePage(QWizardPage):
         self.registerField(
             "schematisation_name*", self.main_widget.le_schematisation_name
         )
-        self.registerField("from_geopackage", self.main_widget.rb_existing_geopackage)
-        self.registerField("geopackage_path", self.main_widget.le_geopackage_path)
-        self.main_widget.rb_existing_geopackage.toggled.connect(self.update_pages_order)
-        self.main_widget.le_schematisation_name.textChanged.connect(
-            self.update_pages_order
-        )
-        self.main_widget.le_geopackage_path.textChanged.connect(self.update_pages_order)
-
         self.registerField(
             "schematisation_description", self.main_widget.le_description
         )
@@ -53,39 +41,11 @@ class SchematisationNamePage(QWizardPage):
             "currentData",
         )
 
-    def update_pages_order(self):
-        """Check if user wants to use an existing GeoPackage and finalize the wizard, if needed."""
-        if self.main_widget.rb_existing_geopackage.isChecked():
-            self.main_widget.le_geopackage_path.setEnabled(True)
-            self.main_widget.btn_browse_geopackage.setEnabled(True)
-            if self.field("geopackage_path"):
-                self.setFinalPage(True)
-        else:
-            self.main_widget.le_geopackage_path.setEnabled(False)
-            self.main_widget.btn_browse_geopackage.setEnabled(False)
-            self.setFinalPage(False)
-        self.completeChanged.emit()
-
     def nextId(self):
-        if self.main_widget.rb_existing_geopackage.isChecked() and self.field(
-            "geopackage_path"
-        ):
-            return -1
-        else:
-            return 1
+        return 1
 
     def isComplete(self):
-        if self.field("schematisation_name") and (
-            self.main_widget.rb_new_geopackage.isChecked()
-            or (
-                self.main_widget.rb_existing_geopackage.isChecked()
-                and self.field("geopackage_path")
-            )
-        ):
-            return True
-
-        else:
-            return False
+        return bool(self.field("schematisation_name"))
 
 
 class SchematisationNameWidget(QWidget):
@@ -152,38 +112,7 @@ class SchematisationNameWidget(QWidget):
             self.cbo_organisations.hide()
 
         gridLayout.addItem(
-            QSpacerItem(20, 25, QSizePolicy.Minimum, QSizePolicy.Fixed), 6, 0
-        )
-
-        gridLayout.addWidget(QLabel("GeoPackage:"), 7, 0)
-
-        gridLayout_2 = QGridLayout()
-        self.rb_new_geopackage = QRadioButton("Create new GeoPackage")
-        self.rb_new_geopackage.setChecked(True)
-        gridLayout_2.addWidget(self.rb_new_geopackage, 0, 0)
-
-        horizontalLayout_2 = QHBoxLayout()
-        horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
-
-        self.rb_existing_geopackage = QRadioButton("Choose file:")
-        horizontalLayout_2.addWidget(self.rb_existing_geopackage)
-
-        self.le_geopackage_path = QLineEdit()
-        self.le_geopackage_path.setEnabled(False)
-        horizontalLayout_2.addWidget(self.le_geopackage_path)
-
-        self.btn_browse_geopackage = QToolButton()
-        self.btn_browse_geopackage.setEnabled(False)
-        self.btn_browse_geopackage.setText("...")
-        horizontalLayout_2.addWidget(self.btn_browse_geopackage)
-        self.btn_browse_geopackage.clicked.connect(self.browse_existing_geopackage)
-
-        gridLayout_2.addLayout(horizontalLayout_2, 2, 0)
-
-        gridLayout.addLayout(gridLayout_2, 7, 2)
-
-        gridLayout.addItem(
-            QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding), 8, 0
+            QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding), 6, 0
         )
 
     def populate_organisations(self):
@@ -193,13 +122,3 @@ class SchematisationNameWidget(QWidget):
         last_organisation = read_3di_settings("threedi/last_used_organisation")
         if last_organisation:
             self.cbo_organisations.setCurrentText(last_organisation)
-
-    def browse_existing_geopackage(self):
-        gpkg_filter = "GeoPackage/SQLite (*.gpkg *.GPKG *.sqlite *SQLITE)"
-        geopackage_path = get_filepath(
-            self,
-            dialog_title="Select Schematisation file",
-            extension_filter=gpkg_filter,
-        )
-        if geopackage_path is not None:
-            self.le_geopackage_path.setText(geopackage_path)

--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -73,6 +73,7 @@ class RanaBrowser(QWidget):
     rename_file_selected = pyqtSignal(dict, dict, str)
     create_folder_selected = pyqtSignal(dict, dict, str)
     upload_new_schematisation_selected = pyqtSignal(dict, dict)
+    upload_existing_schematisation_selected = pyqtSignal(dict, dict)
     import_schematisation_selected = pyqtSignal(dict, dict)
     project_jobs_added = pyqtSignal(list)
     project_job_updated = pyqtSignal(dict)
@@ -328,6 +329,12 @@ class RanaBrowser(QWidget):
         # Connect new schematisation button
         self.files_browser.btn_new_schematisation.clicked.connect(
             lambda _,: self.upload_new_schematisation_selected.emit(
+                self.project, self.selected_item
+            )
+        )
+        # Connect upload existing schematisation button
+        self.files_browser.btn_upload_existing_schematisation.clicked.connect(
+            lambda _,: self.upload_existing_schematisation_selected.emit(
                 self.project, self.selected_item
             )
         )

--- a/rana_qgis_plugin/widgets/schematisation_new_wizard.py
+++ b/rana_qgis_plugin/widgets/schematisation_new_wizard.py
@@ -56,6 +56,52 @@ def feedback_callback_factory(communication):
     return feedback_callback
 
 
+def get_paths_from_geopackage(geopackage_path):
+    """Search GeoPackage database tables for attributes with file paths."""
+    paths = defaultdict(dict)
+    for (
+        table_name,
+        raster_info,
+    ) in SchematisationApiMapper.raster_reference_tables().items():
+        settings_fields = list(raster_info.keys())
+        settings_lyr = geopackage_layer(geopackage_path, table_name)
+        if not settings_lyr.isValid():
+            raise GeoPackageError(
+                f"'{table_name}' table could not be loaded from {geopackage_path}"
+            )
+        try:
+            set_feat = next(settings_lyr.getFeatures())
+        except StopIteration:
+            continue
+        for field_name in settings_fields:
+            field_value = set_feat[field_name]
+            paths[table_name][field_name] = field_value if field_value else None
+    return paths
+
+
+def _create_schematisation_base(tc, working_dir, name, owner, tags, description):
+    """Create schematisation remotely and set up local directory structure.
+
+    Returns a tuple of (schematisation, local_schematisation, wip_revision).
+    """
+    schematisation = tc.create_schematisation(
+        name,
+        owner,
+        tags=tags,
+        meta={"description": description},
+        threedimodel_limit=32767,  # maximum allowed by api
+    )
+    local_schematisation = LocalSchematisation(
+        working_dir,
+        schematisation.id,
+        name,
+        parent_revision_number=0,
+        create=True,
+    )
+    wip_revision = local_schematisation.wip_revision
+    return schematisation, local_schematisation, wip_revision
+
+
 class NewSchematisationWizard(QWizard):
     """New schematisation wizard."""
 
@@ -133,21 +179,9 @@ class NewSchematisationWizard(QWizard):
             self.schematisation_settings_page.main_widget.raster_filepaths()
         )
         try:
-            schematisation = self.tc.create_schematisation(
-                name,
-                owner,
-                tags=tags,
-                meta={"description": description},
-                threedimodel_limit=32767,  # maximum allowed by api
+            schematisation, local_schematisation, wip_revision = _create_schematisation_base(
+                self.tc, self.working_dir, name, owner, tags, description
             )
-            local_schematisation = LocalSchematisation(
-                self.working_dir,
-                schematisation.id,
-                name,
-                parent_revision_number=0,
-                create=True,
-            )
-            wip_revision = local_schematisation.wip_revision
 
             schematisation_filename = f"{name}.gpkg"
             geopackage_filepath = os.path.join(
@@ -216,29 +250,6 @@ class NewSchematisationWizard(QWizard):
             error_msg = f"Error: {e}"
             self.communication.bar_error(error_msg)
 
-    @staticmethod
-    def get_paths_from_geopackage(geopackage_path):
-        """Search GeoPackage database tables for attributes with file paths."""
-        paths = defaultdict(dict)
-        for (
-            table_name,
-            raster_info,
-        ) in SchematisationApiMapper.raster_reference_tables().items():
-            settings_fields = list(raster_info.keys())
-            settings_lyr = geopackage_layer(geopackage_path, table_name)
-            if not settings_lyr.isValid():
-                raise GeoPackageError(
-                    f"'{table_name}' table could not be loaded from {geopackage_path}"
-                )
-            try:
-                set_feat = next(settings_lyr.getFeatures())
-            except StopIteration:
-                continue
-            for field_name in settings_fields:
-                field_value = set_feat[field_name]
-                paths[table_name][field_name] = field_value if field_value else None
-        return paths
-
     def create_schematisation_from_geopackage(self):
         """Get settings from existing GeoPackage and create new schematisation (locally and remotely)."""
         try:
@@ -273,26 +284,13 @@ class NewSchematisationWizard(QWizard):
 
             owner = organisation.unique_id
 
-            schematisation = self.tc.create_schematisation(
-                name,
-                owner,
-                tags=tags,
-                meta={"description": description},
-                threedimodel_limit=32767,  # maximum allowed by api
+            schematisation, local_schematisation, wip_revision = _create_schematisation_base(
+                self.tc, self.working_dir, name, owner, tags, description
             )
-
-            local_schematisation = LocalSchematisation(
-                self.working_dir,
-                schematisation.id,
-                name,
-                parent_revision_number=0,
-                create=True,
-            )
-            wip_revision = local_schematisation.wip_revision
             geopackage_filepath = os.path.join(
                 wip_revision.schematisation_dir, f"{name}.gpkg"
             )
-            raster_paths = self.get_paths_from_geopackage(src_db)
+            raster_paths = get_paths_from_geopackage(src_db)
             src_dir = os.path.dirname(src_db)
             shutil.copyfile(src_db, geopackage_filepath)
             new_paths = defaultdict(dict)

--- a/rana_qgis_plugin/widgets/schematisation_new_wizard.py
+++ b/rana_qgis_plugin/widgets/schematisation_new_wizard.py
@@ -145,34 +145,17 @@ class NewSchematisationWizard(QWizard):
                 f"Schematisation with name {schematisation_name} already exists in working directory. Please choose a different name and try again."
             )
             return
-        if self.schematisation_name_page.field("from_geopackage"):
-            self.create_schematisation_from_geopackage()
-        else:
-            self.create_new_schematisation()
+        self.create_new_schematisation()
 
     def create_new_schematisation(self):
         """Get settings from the wizard and create new schematisation (locally and remotely)."""
         if not self.schematisation_settings_page.settings_are_valid:
             return
 
-        name = self.schematisation_name_page.field("schematisation_name")
-        description = self.schematisation_name_page.field("schematisation_description")
-        tags = self.schematisation_name_page.field("schematisation_tags")
-        if not tags:
-            tags = []
-        else:
-            tags = [tag.strip() for tag in tags.split(",")]
-
-        # when there is exactly one 3Di organisation available for a tenant
-        # no organisation dropdown is shown in the wizard
-        if len(self.available_organisations) > 1:
-            organisation = self.schematisation_name_page.field(
-                "schematisation_organisation"
-            )
-        else:
-            organisation = list(self.available_organisations.values())[0]
-
-        owner = organisation.unique_id
+        name = self.schematisation_name_page.name
+        description = self.schematisation_name_page.description
+        tags = self.schematisation_name_page.tags
+        owner = self.schematisation_name_page.owner
 
         schematisation_settings = self.schematisation_settings_page.main_widget.collect_new_schematisation_settings()
         raster_filepaths = (
@@ -250,39 +233,66 @@ class NewSchematisationWizard(QWizard):
             error_msg = f"Error: {e}"
             self.communication.bar_error(error_msg)
 
-    def create_schematisation_from_geopackage(self):
-        """Get settings from existing GeoPackage and create new schematisation (locally and remotely)."""
-        try:
-            src_db = self.schematisation_name_page.field("geopackage_path")
-            schema_is_valid = ensure_valid_schema(  # possible migration
-                src_db, self.communication
+    def cancel_wizard(self):
+        """Handling canceling wizard action."""
+        QSettings().setValue("threedi/new_schematisation_wizard_size", self.size())
+        self.reject()
+
+
+class UploadExistingSchematisationWizard(QWizard):
+    """Wizard for creating a new schematisation from an existing GeoPackage."""
+
+    def __init__(self, threedi_api, working_dir, communication, organisations, gpkg_path):
+        super().__init__()
+        self.setWizardStyle(QWizard.ClassicStyle)
+        self.working_dir = working_dir
+        self.threedi_api = threedi_api
+        self.tc = ThreediCalls(threedi_api)
+        self.communication = communication
+        self.gpkg_path = gpkg_path
+        self.new_schematisation = None
+        self.new_local_schematisation = None
+        self.available_organisations = organisations
+
+        self.schematisation_name_page = SchematisationNamePage(
+            self.available_organisations, self
+        )
+        self.schematisation_name_page.setFinalPage(True)
+        self.addPage(self.schematisation_name_page)
+        self.setButtonText(QWizard.FinishButton, "Create schematisation")
+        self.finish_btn = self.button(QWizard.FinishButton)
+        self.finish_btn.clicked.connect(self.create_schematisation)
+        self.cancel_btn = self.button(QWizard.CancelButton)
+        self.cancel_btn.clicked.connect(self.cancel_wizard)
+        self.setWindowTitle("Upload existing schematisation")
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setOption(QWizard.HaveNextButtonOnLastPage, False)
+        self.resize(
+            QSettings().value("threedi/new_schematisation_wizard_size", QSize(790, 700))
+        )
+
+    def create_schematisation(self):
+        """Create a new schematisation from the provided GeoPackage."""
+        schematisation_name = self.schematisation_name_page.field("schematisation_name")
+        if schematisation_name in os.listdir(self.working_dir):
+            self.communication.show_error(
+                f"Schematisation with name {schematisation_name} already exists in working directory. Please choose a different name and try again."
             )
+            return
+
+        name = self.schematisation_name_page.name
+        description = self.schematisation_name_page.description
+        tags = self.schematisation_name_page.tags
+        owner = self.schematisation_name_page.owner
+
+        try:
+            src_db = self.gpkg_path
+            schema_is_valid = ensure_valid_schema(src_db, self.communication)
             if schema_is_valid is True:
                 if src_db.lower().endswith(".sqlite"):
                     src_db = src_db.rsplit(".", 1)[0] + ".gpkg"
             else:
                 return  # ensure_valid_schema deals with showing errors.
-
-            name = self.schematisation_name_page.field("schematisation_name")
-            description = self.schematisation_name_page.field(
-                "schematisation_description"
-            )
-            tags = self.schematisation_name_page.field("schematisation_tags")
-            if not tags:
-                tags = []
-            else:
-                tags = [tag.strip() for tag in tags.split(",")]
-
-            # when there is exactly one 3Di organisation available for a tenant
-            # no organisation dropdown is shown in the wizard
-            if len(self.available_organisations) > 1:
-                organisation = self.schematisation_name_page.field(
-                    "schematisation_organisation"
-                )
-            else:
-                organisation = list(self.available_organisations.values())[0]
-
-            owner = organisation.unique_id
 
             schematisation, local_schematisation, wip_revision = _create_schematisation_base(
                 self.tc, self.working_dir, name, owner, tags, description
@@ -293,7 +303,6 @@ class NewSchematisationWizard(QWizard):
             raster_paths = get_paths_from_geopackage(src_db)
             src_dir = os.path.dirname(src_db)
             shutil.copyfile(src_db, geopackage_filepath)
-            new_paths = defaultdict(dict)
             missing_rasters = []
             for table_name, raster_paths_info in raster_paths.items():
                 for raster_name, raster_rel_path in raster_paths_info.items():
@@ -305,11 +314,7 @@ class NewSchematisationWizard(QWizard):
                             wip_revision.raster_dir, os.path.basename(raster_rel_path)
                         )
                         shutil.copyfile(raster_full_path, new_raster_filepath)
-                        new_paths[table_name][raster_name] = os.path.relpath(
-                            new_raster_filepath, wip_revision.schematisation_dir
-                        )
                     else:
-                        new_paths[table_name][raster_name] = None
                         missing_rasters.append((raster_name, raster_rel_path))
             if missing_rasters:
                 missing_rasters.sort(key=itemgetter(0))

--- a/rana_qgis_plugin/widgets/schematisation_new_wizard.py
+++ b/rana_qgis_plugin/widgets/schematisation_new_wizard.py
@@ -162,8 +162,10 @@ class NewSchematisationWizard(QWizard):
             self.schematisation_settings_page.main_widget.raster_filepaths()
         )
         try:
-            schematisation, local_schematisation, wip_revision = _create_schematisation_base(
-                self.tc, self.working_dir, name, owner, tags, description
+            schematisation, local_schematisation, wip_revision = (
+                _create_schematisation_base(
+                    self.tc, self.working_dir, name, owner, tags, description
+                )
             )
 
             schematisation_filename = f"{name}.gpkg"
@@ -242,7 +244,9 @@ class NewSchematisationWizard(QWizard):
 class UploadExistingSchematisationWizard(QWizard):
     """Wizard for creating a new schematisation from an existing GeoPackage."""
 
-    def __init__(self, threedi_api, working_dir, communication, organisations, gpkg_path):
+    def __init__(
+        self, threedi_api, working_dir, communication, organisations, gpkg_path
+    ):
         super().__init__()
         self.setWizardStyle(QWizard.ClassicStyle)
         self.working_dir = working_dir
@@ -294,8 +298,10 @@ class UploadExistingSchematisationWizard(QWizard):
             else:
                 return  # ensure_valid_schema deals with showing errors.
 
-            schematisation, local_schematisation, wip_revision = _create_schematisation_base(
-                self.tc, self.working_dir, name, owner, tags, description
+            schematisation, local_schematisation, wip_revision = (
+                _create_schematisation_base(
+                    self.tc, self.working_dir, name, owner, tags, description
+                )
             )
             geopackage_filepath = os.path.join(
                 wip_revision.schematisation_dir, f"{name}.gpkg"

--- a/rana_qgis_plugin/widgets/schematisation_new_wizard.py
+++ b/rana_qgis_plugin/widgets/schematisation_new_wizard.py
@@ -79,6 +79,19 @@ def get_paths_from_geopackage(geopackage_path):
     return paths
 
 
+def _check_name_available(name, working_dir, communication):
+    """Check if schematisation name is available in the working directory.
+
+    Returns True if available, False if not (and shows an error).
+    """
+    if name in os.listdir(working_dir):
+        communication.show_error(
+            f"Schematisation with name {name} already exists in working directory. Please choose a different name and try again."
+        )
+        return False
+    return True
+
+
 def _create_schematisation_base(tc, working_dir, name, owner, tags, description):
     """Create schematisation remotely and set up local directory structure.
 
@@ -139,11 +152,8 @@ class NewSchematisationWizard(QWizard):
         )
 
     def create_schematisation(self):
-        schematisation_name = self.schematisation_name_page.field("schematisation_name")
-        if schematisation_name in os.listdir(self.working_dir):
-            self.communication.show_error(
-                f"Schematisation with name {schematisation_name} already exists in working directory. Please choose a different name and try again."
-            )
+        name = self.schematisation_name_page.name
+        if not _check_name_available(name, self.working_dir, self.communication):
             return
         self.create_new_schematisation()
 
@@ -277,14 +287,10 @@ class UploadExistingSchematisationWizard(QWizard):
 
     def create_schematisation(self):
         """Create a new schematisation from the provided GeoPackage."""
-        schematisation_name = self.schematisation_name_page.field("schematisation_name")
-        if schematisation_name in os.listdir(self.working_dir):
-            self.communication.show_error(
-                f"Schematisation with name {schematisation_name} already exists in working directory. Please choose a different name and try again."
-            )
+        name = self.schematisation_name_page.name
+        if not _check_name_available(name, self.working_dir, self.communication):
             return
 
-        name = self.schematisation_name_page.name
         description = self.schematisation_name_page.description
         tags = self.schematisation_name_page.tags
         owner = self.schematisation_name_page.owner


### PR DESCRIPTION
- Split wizard in two classes `NewSchematisationWizard` and `UploadExistingSchematisationWizard` with shared functionality in module level functions
- Add `upload_existing_schematisation_to_rana` to `Loader` and move duplicate code from `upload_existing_schematisation_to_rana` to seperate method or function
- Add buttons and connections