### PR TITLE
Re-organize actions in FilesBrowser

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ History
 - Remove results download folder on canceling download (nens/rana-qgis-plugin#323)
 - Split new schematisation from scratch and new schematisation from file functionality (nens/rana#4224)
 - Add open in browser functionality to files (context menu), file view (button) and revivisions view (context menu) (nens/rana#3732)
+- Organize add schematisation actions in files in menu and move "create new folder" to context menu on empty space (nens/rana#4254)
 
 
 1.2.12 (2026-05-06)

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -143,6 +143,8 @@ class FilesBrowser(QWidget):
         )
         self.files_tv.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.files_tv.customContextMenuRequested.connect(self.menu_requested)
+        # Ensure there is always empty space at the bottom for right-click context menu
+        self.files_tv.setViewportMargins(0, 0, 0, 30)
         self.files_model = FileBrowserModel()
         self.files_tv.setModel(self.files_model)
         self.files_tv.setSortingEnabled(True)
@@ -163,13 +165,18 @@ class FilesBrowser(QWidget):
         self.select_btn.setToolTip("Toggle file selection mode")
         self.select_btn.toggled.connect(self.toggle_select_mode)
         self.btn_upload = QPushButton("Upload Files to Rana")
-        btn_create_folder = QPushButton("Create New Folder")
-        btn_create_folder.clicked.connect(self.show_create_folder_dialog)
+        self.btn_upload.setIcon(
+            QgsApplication.getThemeIcon("/mActionSharingExport.svg")
+        )
+        self.btn_upload.setToolTip("Upload your files to Rana Web Platform")
         # Add schematisation menu button
         self.btn_add_schematisation = QToolButton()
-        self.btn_add_schematisation.setText("Add schematisation")
+        self.btn_add_schematisation.setText("Upload schematisation")
         self.btn_add_schematisation.setIcon(
             QgsApplication.getThemeIcon("/mActionAdd.svg")
+        )
+        self.btn_add_schematisation.setToolTip(
+            "Add schematisation on Rana web platform"
         )
         self.btn_add_schematisation.setToolButtonStyle(
             Qt.ToolButtonStyle.ToolButtonTextBesideIcon
@@ -178,16 +185,26 @@ class FilesBrowser(QWidget):
             QToolButton.ToolButtonPopupMode.InstantPopup
         )
         schematisation_menu = QMenu(self.btn_add_schematisation)
+        schematisation_menu.setToolTipsVisible(True)
         self.action_new_schematisation = schematisation_menu.addAction(
             QgsApplication.getThemeIcon("/mActionNewPage.svg"), "New schematisation"
+        )
+        self.action_new_schematisation.setToolTip(
+            "Create a new schematisation on Rana web platform"
         )
         self.action_upload_existing_schematisation = schematisation_menu.addAction(
             QgsApplication.getThemeIcon("/mActionFileOpen.svg"),
             "Upload existing schematisation",
         )
+        self.action_upload_existing_schematisation.setToolTip(
+            "Upload your local schematisation to Rana web platform"
+        )
         self.action_import_schematisation = schematisation_menu.addAction(
             QgsApplication.getThemeIcon("/mActionSharingImport.svg"),
             "Import schematisation",
+        )
+        self.action_import_schematisation.setToolTip(
+            "Import a schematisation from the model databank into Rana Webplatform"
         )
         self.btn_add_schematisation.setMenu(schematisation_menu)
         # Page 0: Normal mode buttons
@@ -196,7 +213,6 @@ class FilesBrowser(QWidget):
         row1 = QHBoxLayout()
         row1.addWidget(self.btn_upload)
         row1.addWidget(self.btn_add_schematisation)
-        row1.addWidget(btn_create_folder)
         btn_layout.addLayout(row1)
         # Page 1: Select mode buttons
         select_page = QWidget()
@@ -387,12 +403,41 @@ class FilesBrowser(QWidget):
             self.file_selected.emit(self.selected_item)
         self.communication.clear_message_bar()
 
+    def _show_empty_space_menu(self, pos):
+        """Show a context menu with only the 'Create new folder' action."""
+        menu = QMenu(self)
+        action = QAction("Create new folder", self)
+        action.setIcon(QgsApplication.getThemeIcon("/mActionNewFolder.svg"))
+        action.triggered.connect(self.show_create_folder_dialog)
+        menu.addAction(action)
+        menu.popup(self.files_tv.viewport().mapToGlobal(pos))
+
     def menu_requested(self, pos):
         index = self.files_tv.indexAt(pos)
         file_item = self.files_model.itemFromIndex(index)
-        if not file_item:
+
+        # Click on empty space (below all rows): show create folder menu
+        if not index.isValid() or not file_item:
+            self._show_empty_space_menu(pos)
             return
+
         selected_item = file_item.data(Qt.ItemDataRole.UserRole)
+
+        # Click on an empty column of a folder row (cols 2-4 have no item data
+        # for folders): show create folder menu
+        if not selected_item:
+            self._show_empty_space_menu(pos)
+            return
+
+        # Click on a file row in a non-name column: no context menu
+        if index.column() != 1 and selected_item["type"] != "directory":
+            return
+
+        # Click on an item: show item menu
+        self._show_item_menu(pos, index, selected_item)
+
+    def _show_item_menu(self, pos, index, selected_item):
+        """Show a context menu with actions for the selected file/folder."""
         # For scenarios, fetch the descriptor once and reuse it
         descriptor = None
         if selected_item.get("data_type") == "scenario":

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from qgis.core import QgsApplication
 from qgis.PyQt.QtCore import (
     QModelIndex,
     Qt,
@@ -23,6 +24,7 @@ from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QStackedWidget,
     QStyle,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -163,23 +165,39 @@ class FilesBrowser(QWidget):
         self.btn_upload = QPushButton("Upload Files to Rana")
         btn_create_folder = QPushButton("Create New Folder")
         btn_create_folder.clicked.connect(self.show_create_folder_dialog)
-        self.btn_new_schematisation = QPushButton("New schematisation")
-        self.btn_import_schematisation = QPushButton("Import schematisation")
-        self.btn_upload_existing_schematisation = QPushButton(
-            "Upload existing schematisation"
+        # Add schematisation menu button
+        self.btn_add_schematisation = QToolButton()
+        self.btn_add_schematisation.setText("Add schematisation")
+        self.btn_add_schematisation.setIcon(
+            QgsApplication.getThemeIcon("/mActionAdd.svg")
         )
+        self.btn_add_schematisation.setToolButtonStyle(
+            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self.btn_add_schematisation.setPopupMode(
+            QToolButton.ToolButtonPopupMode.InstantPopup
+        )
+        schematisation_menu = QMenu(self.btn_add_schematisation)
+        self.action_new_schematisation = schematisation_menu.addAction(
+            QgsApplication.getThemeIcon("/mActionNewPage.svg"), "New schematisation"
+        )
+        self.action_upload_existing_schematisation = schematisation_menu.addAction(
+            QgsApplication.getThemeIcon("/mActionFileOpen.svg"),
+            "Upload existing schematisation",
+        )
+        self.action_import_schematisation = schematisation_menu.addAction(
+            QgsApplication.getThemeIcon("/mActionSharingImport.svg"),
+            "Import schematisation",
+        )
+        self.btn_add_schematisation.setMenu(schematisation_menu)
         # Page 0: Normal mode buttons
         normal_page = QWidget()
         btn_layout = QVBoxLayout(normal_page)
         row1 = QHBoxLayout()
         row1.addWidget(self.btn_upload)
+        row1.addWidget(self.btn_add_schematisation)
         row1.addWidget(btn_create_folder)
-        row2 = QHBoxLayout()
-        row2.addWidget(self.btn_new_schematisation)
-        row2.addWidget(self.btn_upload_existing_schematisation)
-        row2.addWidget(self.btn_import_schematisation)
         btn_layout.addLayout(row1)
-        btn_layout.addLayout(row2)
         # Page 1: Select mode buttons
         select_page = QWidget()
         select_layout = QHBoxLayout(select_page)
@@ -206,9 +224,7 @@ class FilesBrowser(QWidget):
         layout.addWidget(self.btn_stack)
         self.setLayout(layout)
 
-        self.btn_new_schematisation.setVisible(has_3di_authcfg())
-        self.btn_import_schematisation.setVisible(has_3di_authcfg())
-        self.btn_upload_existing_schematisation.setVisible(has_3di_authcfg())
+        self.btn_add_schematisation.setVisible(has_3di_authcfg())
         # Connect checkbox state changes to update batch button states
         self.files_model.itemChanged.connect(self._update_batch_buttons)
 

--- a/rana_qgis_plugin/widgets/rana_browser.py
+++ b/rana_qgis_plugin/widgets/rana_browser.py
@@ -326,20 +326,20 @@ class RanaBrowser(QWidget):
         )
         self.publication_view.save_styles_to_rana.connect(self.disable)
         self.publication_view.save_styles_finished.connect(self.enable)
-        # Connect new schematisation button
-        self.files_browser.btn_new_schematisation.clicked.connect(
+        # Connect new schematisation action
+        self.files_browser.action_new_schematisation.triggered.connect(
             lambda _,: self.upload_new_schematisation_selected.emit(
                 self.project, self.selected_item
             )
         )
-        # Connect upload existing schematisation button
-        self.files_browser.btn_upload_existing_schematisation.clicked.connect(
+        # Connect upload existing schematisation action
+        self.files_browser.action_upload_existing_schematisation.triggered.connect(
             lambda _,: self.upload_existing_schematisation_selected.emit(
                 self.project, self.selected_item
             )
         )
-        # Connect import schematisation button
-        self.files_browser.btn_import_schematisation.clicked.connect(
+        # Connect import schematisation action
+        self.files_browser.action_import_schematisation.triggered.connect(
             lambda _,: self.import_schematisation_selected.emit(
                 self.project, self.selected_item
             )


### PR DESCRIPTION
- Replace schematisation buttons with dropdown menu
- Move create folder to context menu on empty space
- Add a bit of white space at the bottom of the table so there is always some white space for the context menu
- Add icons and tooltips to buttons and menu items (except for file actions)