### PR TITLE
Improve names of tracker processes (#295)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 - Set custom colors for the progress bar (nens/rana-qgis-plugin#294)
 - Remove unnecessary back and next buttons from upload schematisation wizard (nens/rana#4408)
 - Remove adding max waterdepth which is now handled by the results analysis plugin (nens/rana#4349)
+- Added process name table to Processes table and improved names of tracker processes (#295)
 
 
 1.2.14 (2026-06-17)

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -1080,7 +1080,7 @@ class Loader(QObject):
                 "inherit_from_previous_model": True,
                 "inherit_from_previous_revision": inherit_from_previous_revision,
             },
-            "name": f"model_tracker_{schematisation['name']}_rev{revision_id}",
+            "name": f"{schematisation['name']}_rev{revision_id}",
         }
         _ = start_tenant_process(self.communication, track_process, params)
         self.model_created.emit()
@@ -1105,7 +1105,7 @@ class Loader(QObject):
                         "id": f"{output_file_path}{sim.simulation.name}_{sim.simulation.id}_results.zip"
                     }
                 },
-                "name": f"simulation_tracker_{sim.simulation.name}",
+                "name": f"{sim.simulation.name}",
             }
             _ = start_tenant_process(self.communication, track_process, params)
 

--- a/rana_qgis_plugin/widgets/processes_browser.py
+++ b/rana_qgis_plugin/widgets/processes_browser.py
@@ -55,6 +55,7 @@ class JobData:
     progress: int
     max_progress: int
     process_id: int | None
+    process_name: str | None
     inputs: dict
 
     def progress_str(self):
@@ -80,6 +81,7 @@ class JobData:
                 progress=int(100 * job["state"]["progress"]),
                 max_progress=100,
                 process_id=job["process"].get("id") if job["process"] else None,
+                process_name=job["process"].get("name") if job["process"] else None,
                 inputs=job["inputs"],
             )
         except Exception as e:
@@ -118,10 +120,10 @@ class ProcessesBrowser(QWidget):
         self.setLayout(layout)
         # create root items, they will be added on populating
         self.processes_model.setHorizontalHeaderLabels(
-            ["Name", "Who", "Started", "Status"]
+            ["Name", "Process name", "Who", "Started", "Status"]
         )
         avatar_delegate = ContributorAvatarsDelegate(self.processes_tv)
-        self.processes_tv.setItemDelegateForColumn(1, avatar_delegate)
+        self.processes_tv.setItemDelegateForColumn(2, avatar_delegate)
         name_delegate = WordWrapDelegate(self.processes_tv)
         self.processes_tv.setItemDelegateForColumn(0, name_delegate)
         self.processes_tv.setWordWrap(True)
@@ -138,6 +140,10 @@ class ProcessesBrowser(QWidget):
         name_link = QLabel("")
         self.update_job_link(name_link, job)
         name_link.setToolTip(job.name)
+
+        process_name_item = QStandardItem()
+        process_name_item.setText(str(job.process_name))
+
         who_item = QStandardItem()
         who_item.setData(
             [
@@ -181,7 +187,7 @@ class ProcessesBrowser(QWidget):
         status_container = QWidget()
         status_container.setLayout(status_layout)
         status_container.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
-        row = [name_item, who_item, date_item, status_item]
+        row = [name_item, process_name_item, who_item, date_item, status_item]
         self.processes_model.insertRow(0, row)
         self.processes_tv.setIndexWidget(status_item.index(), status_container)
         for id in self.row_map:
@@ -239,7 +245,7 @@ class ProcessesBrowser(QWidget):
         row = self.row_map.get(job.id, -1)
         if row < 0:
             return
-        status_item = self.processes_model.item(row, 3)
+        status_item = self.processes_model.item(row, 4)
         status_item.setData(job.status, Qt.ItemDataRole.UserRole)
         # retrieve progress bar and cancel button, and update their status
         status_layout = self.processes_tv.indexWidget(status_item.index()).layout()


### PR DESCRIPTION
Added column "Process name" to Processes table (just like frontend)

<img width="936" height="197" alt="image" src="https://github.com/user-attachments/assets/52c725b9-aad0-42a5-93f0-709b973c8e97" />


Reduced names of simulation and model tracker jobs.