### PR TITLE
Case upload conflicts

### DIFF
--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import uuid
+from pathlib import Path
 
 import pytest
 from qgis.core import QgsApplication, QgsAuthMethodConfig
@@ -346,3 +348,73 @@ def test_select_download_and_delete(plugin, qtbot, request, rana_project):
     assert _find_file_row(files_browser, "upload.gpkg") is None, (
         "upload.gpkg should have been deleted from the file list"
     )
+
+
+def test_upload_case_conflict(plugin, qtbot, request, rana_project):
+    """Uploading a file whose name matches an existing server file case-insensitively
+    should warn the user and not complete the upload."""
+    plugin.iface.mainWindow().setWindowTitle(request.node.nodeid)
+    _open_project(plugin, qtbot, rana_project)
+
+    # Phase 1: upload upload.gpkg to establish a server-side file.
+    # Dismiss the "load layer?" prompt with Escape to avoid opening the file in the plugin.
+    def dismiss_load_layer(qtbot, modal):
+        qtbot.keyClick(modal, Qt.Key.Key_Escape)
+
+    QTimer.singleShot(500, make_modal_handler(qtbot, QMessageBox, dismiss_load_layer))
+
+    with qtbot.waitSignal(plugin.loader.file_upload_finished, timeout=30000):
+
+        def handle_dialog_select_upload(qtbot, modal):
+            QTest.qWait(500)
+            modal.selectFile("upload.gpkg")
+            QTest.qWait(500)
+            qtbot.keyClick(modal, Qt.Key.Key_Enter)
+
+        QTimer.singleShot(
+            500, make_modal_handler(qtbot, QFileDialog, handle_dialog_select_upload)
+        )
+        QTest.mouseClick(plugin.rana_browser.files_browser.btn_upload, Qt.LeftButton)
+
+    # Phase 2: attempt to upload Upload.gpkg (case-variant of the file already on the server).
+    # The API should reject it with a 400; the plugin should emit file_upload_failed
+    # and show a warning rather than completing the upload.
+    original_file = Path(__file__).parent.resolve().joinpath("data", "upload.gpkg")
+    case_dup_file = Path(__file__).parent.resolve().joinpath("data", "Upload.gpkg")
+    if not case_dup_file.exists():
+        shutil.copy(original_file, case_dup_file)
+
+    error_shown = []
+
+    def dismiss_error(qtbot, modal):
+        error_shown.append(modal.text())
+        qtbot.keyClick(modal, Qt.Key.Key_Enter)
+
+    QTimer.singleShot(500, make_modal_handler(qtbot, QMessageBox, dismiss_error))
+
+    with qtbot.waitSignal(plugin.loader.file_upload_failed, timeout=15000):
+
+        def handle_dialog_select_case_variant(qtbot, modal):
+            QTest.qWait(500)
+            modal.selectFile("Upload.gpkg")
+            QTest.qWait(500)
+            qtbot.keyClick(modal, Qt.Key.Key_Enter)
+
+        QTimer.singleShot(
+            500,
+            make_modal_handler(qtbot, QFileDialog, handle_dialog_select_case_variant),
+        )
+        QTest.mouseClick(plugin.rana_browser.files_browser.btn_upload, Qt.LeftButton)
+
+    # An error dialog must have been shown mentioning case sensitivity.
+    assert error_shown, "Expected an error dialog to appear for the case-conflict"
+
+    # The case-variant must not appear as a new file in the browser.
+    assert _find_file_row(plugin.rana_browser.files_browser, "Upload.gpkg") is None, (
+        "Upload.gpkg should not have been uploaded to the server"
+    )
+    # The original file must still be present.
+    assert (
+        _find_file_row(plugin.rana_browser.files_browser, "upload.gpkg") is not None
+    ), "upload.gpkg should still be present on the server"
+    case_dup_file.unlink()

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -829,35 +829,12 @@ class Loader(QObject):
         sender.deleteLater()
         # setup upload worker
         local_path = sender.downloader.downloaded_file_path
-        online_path = Path(online_dir).joinpath(local_path.name).as_posix()
-        file = get_tenant_project_file(project["id"], {"path": online_path})
-        if file:
-            user = file.get("user") or {}
-            if not user or "given_name" not in user or "family_name" not in user:
-                created_by = "unknown"
-            else:
-                created_by = f"{user['given_name']} {user['family_name']}"
-            created_at = convert_timestamp_str_to_local_time(file["last_modified"])
-            if self.communication.ask(
-                self.parent(),
-                "File already exists",
-                f"File {local_path.name} at {online_path} was already created at {created_at} by {created_by}. Do you want to replace is?",
-            ):
-                self.file_upload_worker = ExistingFileUploadWorker(
-                    project, file, local_path
-                )
-                self.file_upload_worker.file_overwrite = True
-                worker = self.file_upload_worker
-            else:
-                self.communication.clear_message_bar()
-                self.file_upload_failed.emit("")
-                return
-        else:
-            self.new_file_upload_worker = FileUploadWorker(
-                project, [local_path], online_dir
-            )
-            worker = self.new_file_upload_worker
+        self.new_file_upload_worker = FileUploadWorker(
+            project, [local_path], online_dir, ask_overwrite_permission=True
+        )
+        worker = self.new_file_upload_worker
 
+        worker.conflict.connect(self.handle_file_conflict)
         worker.failed.connect(self.on_file_upload_failed)
         worker.failed.connect(lambda error: self.file_upload_failed.emit(error))
         worker.progress.connect(self.on_file_upload_progress)
@@ -1403,16 +1380,10 @@ class Loader(QObject):
             lambda msg: self.communication.show_warn(msg)
         )
 
-    def handle_file_conflict(self):
-        warn_and_ask_msg = (
-            "The file has been modified on the server since it was last downloaded.\n"
-            "Do you want to overwrite the server copy with the local copy?"
-        )
-        file_overwrite = self.communication.ask(
-            self.parent(), "File conflict", warn_and_ask_msg
-        )
+    def handle_file_conflict(self, message: str):
         sender = self.sender()
         assert isinstance(sender, QThread)
+        file_overwrite = self.communication.ask(self.parent(), "File conflict", message)
         sender.file_overwrite = file_overwrite
 
     @cleanup_sender

--- a/rana_qgis_plugin/utils/api.py
+++ b/rana_qgis_plugin/utils/api.py
@@ -513,18 +513,24 @@ def start_tenant_process(communication: UICommunication, process_id, params: dic
 
 
 def start_file_upload(project_id: str, params: dict):
+    """Initiate a file upload.
+
+    Returns:
+        Tuple of (response, error_body). On success, response is the parsed JSON dict and
+        error_body is None. On failure, response is None and error_body is the parsed error
+        JSON dict (or None if the response body was not parseable).
+    """
     authcfg_id = get_authcfg_id()
     tenant = get_tenant_id()
     url = f"{api_url()}/tenants/{tenant}/projects/{project_id}/files/upload"
 
     network_manager = NetworkManager(url, authcfg_id)
-    status = network_manager.post(params=params)
+    status, _ = network_manager.post(params=params)
 
     if status:
-        response = network_manager.content
-        return response
+        return network_manager.content, None
     else:
-        return None
+        return None, network_manager.content
 
 
 def finish_file_upload(project_id: str, payload: dict):

--- a/rana_qgis_plugin/workers/upload.py
+++ b/rana_qgis_plugin/workers/upload.py
@@ -81,7 +81,7 @@ class FileUploadWorker(QThread):
         try:
             self.progress.emit(progress_start, "")
             # Step 1: POST request to initiate the upload
-            upload_response = start_file_upload(
+            upload_response, _error = start_file_upload(
                 self.project["id"], {"path": online_path}
             )
             if not upload_response:

--- a/rana_qgis_plugin/workers/upload.py
+++ b/rana_qgis_plugin/workers/upload.py
@@ -16,30 +16,80 @@ from rana_qgis_plugin.utils.api import (
     start_file_upload,
 )
 from rana_qgis_plugin.utils.local_paths import get_local_file_path
+from rana_qgis_plugin.utils.time import convert_timestamp_str_to_local_time
+
+
+def _extract_case_conflict_path(error: dict) -> str | None:
+    """Extract the conflicting server path from a 400 case-conflict error body.
+
+    The API returns detail[0].ctx.path when a file with the same name (different
+    case) already exists. Returns None if the error body does not match this shape.
+    """
+    try:
+        return error["detail"][0]["ctx"]["path"]
+    except (KeyError, IndexError, TypeError):
+        return None
 
 
 class FileUploadWorker(QThread):
-    """Worker thread for uploading new (non-rana) files."""
+    """Worker thread for uploading new (non-rana) files.
+
+    When ask_overwrite_permission is True, the worker emits `conflict` and waits
+    for `file_overwrite` to be set by the caller instead of failing immediately
+    when a name conflict is detected (exact match or case-insensitive).
+    """
 
     progress = pyqtSignal(int, str)
     finished = pyqtSignal(dict)
-    conflict = pyqtSignal()
+    conflict = pyqtSignal(str)
     failed = pyqtSignal(str)
     warning = pyqtSignal(str)
 
-    def __init__(self, project: dict, local_paths: list[Path], online_dir: str):
+    def __init__(
+        self,
+        project: dict,
+        local_paths: list[Path],
+        online_dir: str,
+        ask_overwrite_permission: bool = False,
+    ):
         super().__init__()
         self.project = project
         self.local_paths = local_paths
         if online_dir and not online_dir.endswith("/"):
             online_dir += "/"
         self.online_dir = online_dir
+        self.ask_overwrite_permission = ask_overwrite_permission
+        self.file_overwrite = None
+
+    def _ask_overwrite(self, online_path: str, server_file: dict) -> bool:
+        """Build conflict message from server_file, emit conflict, block until decided."""
+        user = server_file.get("user") or {}
+        if "given_name" in user and "family_name" in user:
+            created_by = f"{user['given_name']} {user['family_name']}"
+        else:
+            created_by = "unknown"
+        created_at = convert_timestamp_str_to_local_time(server_file["last_modified"])
+        message = (
+            f"File {Path(online_path).name} at {online_path} was already "
+            f"created at {created_at} by {created_by}.\n"
+            f"Do you want to replace it?"
+        )
+        self.file_overwrite = None
+        self.conflict.emit(message)
+        while self.file_overwrite is None:
+            self.msleep(100)
+        return self.file_overwrite
 
     def handle_file_conflict(self, online_path):
         server_file = get_tenant_project_file(self.project["id"], {"path": online_path})
         if server_file:
-            self.failed.emit("File already exist on server.")
-            return False
+            if self.ask_overwrite_permission:
+                if not self._ask_overwrite(online_path, server_file):
+                    self.failed.emit("File upload aborted.")
+                    return False
+            else:
+                self.failed.emit("File already exists on server.")
+                return False
         return True  # Continue to upload
 
     def update_payload(self, payload):
@@ -64,6 +114,42 @@ class FileUploadWorker(QThread):
     def get_online_path(self, local_path: Path) -> str:
         return f"{self.online_dir}{local_path.name}"
 
+    def _initiate_upload(self, online_path: str) -> dict | None:
+        """POST to start the upload. Returns the upload response or None on failure.
+
+        On a case-insensitive conflict (API 400 with ctx.path): if
+        ask_overwrite_permission is True, emits `conflict`, waits for approval,
+        then retries with the server-side path from ctx.path. Otherwise fails.
+        """
+        upload_response, error = start_file_upload(
+            self.project["id"], {"path": online_path}
+        )
+        if not upload_response:
+            conflict_path = _extract_case_conflict_path(error)
+            if conflict_path and self.ask_overwrite_permission:
+                server_file = get_tenant_project_file(
+                    self.project["id"], {"path": conflict_path}
+                )
+                if not self._ask_overwrite(conflict_path, server_file or {}):
+                    self.failed.emit("File upload aborted.")
+                    return None
+                upload_response, error = start_file_upload(
+                    self.project["id"], {"path": conflict_path}
+                )
+                if not upload_response:
+                    self.failed.emit("Failed to initiate file upload.")
+                    return None
+            elif conflict_path:
+                self.failed.emit(
+                    f"File not uploaded: a file named '{Path(conflict_path).name}' "
+                    f"already exists on the server. File names must be unique and case differences are ignored."
+                )
+                return None
+            else:
+                self.failed.emit("Failed to initiate file upload.")
+                return None
+        return upload_response
+
     def upload_single_file(
         self, local_path: Path, progress_start, progress_step
     ) -> bool:
@@ -81,11 +167,8 @@ class FileUploadWorker(QThread):
         try:
             self.progress.emit(progress_start, "")
             # Step 1: POST request to initiate the upload
-            upload_response, _error = start_file_upload(
-                self.project["id"], {"path": online_path}
-            )
+            upload_response = self._initiate_upload(online_path)
             if not upload_response:
-                self.failed.emit("Failed to initiate file upload.")
                 return False
             upload_url = upload_response["urls"][0]
             # Step 2: Upload the file to the upload_url
@@ -159,7 +242,10 @@ class ExistingFileUploadWorker(FileUploadWorker):
             return False
         self.last_modified = server_file["last_modified"]
         if self.last_modified != local_last_modified:
-            self.conflict.emit()
+            self.conflict.emit(
+                "The file has been modified on the server since it was last downloaded.\n"
+                "Do you want to overwrite the server copy with the local copy?"
+            )
             while self.file_overwrite is None:
                 self.msleep(100)
             if self.file_overwrite is False:


### PR DESCRIPTION
This PR modifies the upload workers to properly respond when the upload fails because the filename has a case insensitive clash with existing files. There were 3 upload paths with different behavior:
1. Upload new file to rana: always fail on clash
2. Upload schematisation export to rana: ask user for overwrite permission (because user has no influence on filename)
3. Upload existing file to rana

For 3 no changes are needed because the `file["id"]` always holds the correct path.

The other ones differ in wether the user can choose to overwrite. For this the FileUploadWorker was extended with `ask_overwrite_persmission`; if set to True a dialog is opened on clash (both on exact and case insensitive match). This option is only activated for the gpkg upload.

closes https://github.com/nens/rana/issues/4497
