### PR TITLE
Debug e2e test

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -200,21 +200,5 @@ def plugin(qgis_iface, qgis_application):
     plugin.initGui()
     yield plugin
 
-    # if plugin.loader:
-    # Stop the persistent scheduler timer and drain its task queue before
-    # unload so no new network requests are dispatched into worker threads
-    # during teardown.
-    # plugin.loader.persistent_scheduler.stop()
-    # plugin.loader.persistent_scheduler.clear()
-    # Cancel the avatar worker and wait long enough for any in-flight fetch
-    # to complete before unload() destroys the QgsApplication objects the
-    # worker thread accesses.
-    # if plugin.loader.avatar_worker:
-    #     plugin.loader.avatar_worker.cancel()
-    # plugin.loader.avatar_runner_pool.waitForDone(15000)
-    # Stop the auto-refresh timer and remove the window event filter before unload
-    # if plugin.rana_browser:
-    #     plugin.rana_browser.refresh_timer.stop()
-    #     plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
     plugin.unload()
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -200,30 +200,21 @@ def plugin(qgis_iface, qgis_application):
     plugin.initGui()
     yield plugin
 
-    # Stop the persistent scheduler timer and drain its task queue before
-    # unload so no new network requests are dispatched into worker threads
-    # during teardown.
     if plugin.loader:
+        # Stop the persistent scheduler timer and drain its task queue before
+        # unload so no new network requests are dispatched into worker threads
+        # during teardown.
         plugin.loader.persistent_scheduler.stop()
         plugin.loader.persistent_scheduler.clear()
-    # Stop the auto-refresh timer and remove the window event filter before
-    # unload.  Both can trigger auto_refresh() -> fetch_and_populate() ->
-    # NetworkManager.fetch() during any processEvents() spin, including the
-    # one inside delete_project() in rana_project teardown.  Removing the
-    # filter also prevents WindowActivate events from firing during teardown.
-    if plugin.rana_browser:
-        plugin.rana_browser.refresh_timer.stop()
-        plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
-    # Cancel the avatar worker and wait long enough for any in-flight fetch
-    # to complete before unload() destroys the QgsApplication objects the
-    # worker thread accesses.  loader.cleanup() only waits 500ms which is
-    # too short; we extend it here.  The persistent scheduler pool is NOT
-    # waited on — its workers also call processEvents() from a thread, which
-    # deadlocks if waited on from the main thread; stopping+clearing above is
-    # sufficient to prevent new work from starting.
-    if plugin.loader:
+        # Cancel the avatar worker and wait long enough for any in-flight fetch
+        # to complete before unload() destroys the QgsApplication objects the
+        # worker thread accesses.
         if plugin.loader.avatar_worker:
             plugin.loader.avatar_worker.cancel()
         plugin.loader.avatar_runner_pool.waitForDone(15000)
+    # Stop the auto-refresh timer and remove the window event filter before unload
+    if plugin.rana_browser:
+        plugin.rana_browser.refresh_timer.stop()
+        plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
     plugin.unload()
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -201,4 +201,15 @@ def plugin(qgis_iface, qgis_application):
     yield plugin
 
     plugin.unload()
+    # Process any queued cancel signals before waiting
+    qgis_application.processEvents()
+    # Wait for background threads to finish before QGIS teardown.
+    # loader.cleanup() uses waitForDone(500) which is too short when a
+    # network request is in-flight. We wait here with a longer timeout so
+    # the worker thread is guaranteed dead before exitQgis() runs, avoiding
+    # a segfault or hang caused by the thread accessing a destroyed
+    # QgsApplication.
+    if plugin.loader:
+        plugin.loader.avatar_runner_pool.waitForDone(15000)
+        plugin.loader.persistent_scheduler.thread_pool.waitForDone(15000)
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -200,21 +200,21 @@ def plugin(qgis_iface, qgis_application):
     plugin.initGui()
     yield plugin
 
-    if plugin.loader:
-        # Stop the persistent scheduler timer and drain its task queue before
-        # unload so no new network requests are dispatched into worker threads
-        # during teardown.
-        plugin.loader.persistent_scheduler.stop()
-        plugin.loader.persistent_scheduler.clear()
-        # Cancel the avatar worker and wait long enough for any in-flight fetch
-        # to complete before unload() destroys the QgsApplication objects the
-        # worker thread accesses.
-        if plugin.loader.avatar_worker:
-            plugin.loader.avatar_worker.cancel()
-        plugin.loader.avatar_runner_pool.waitForDone(15000)
+    # if plugin.loader:
+    # Stop the persistent scheduler timer and drain its task queue before
+    # unload so no new network requests are dispatched into worker threads
+    # during teardown.
+    # plugin.loader.persistent_scheduler.stop()
+    # plugin.loader.persistent_scheduler.clear()
+    # Cancel the avatar worker and wait long enough for any in-flight fetch
+    # to complete before unload() destroys the QgsApplication objects the
+    # worker thread accesses.
+    # if plugin.loader.avatar_worker:
+    #     plugin.loader.avatar_worker.cancel()
+    # plugin.loader.avatar_runner_pool.waitForDone(15000)
     # Stop the auto-refresh timer and remove the window event filter before unload
-    if plugin.rana_browser:
-        plugin.rana_browser.refresh_timer.stop()
-        plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
+    # if plugin.rana_browser:
+    #     plugin.rana_browser.refresh_timer.stop()
+    #     plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
     plugin.unload()
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -214,5 +214,16 @@ def plugin(qgis_iface, qgis_application):
     if plugin.rana_browser:
         plugin.rana_browser.refresh_timer.stop()
         plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
+    # Cancel the avatar worker and wait long enough for any in-flight fetch
+    # to complete before unload() destroys the QgsApplication objects the
+    # worker thread accesses.  loader.cleanup() only waits 500ms which is
+    # too short; we extend it here.  The persistent scheduler pool is NOT
+    # waited on — its workers also call processEvents() from a thread, which
+    # deadlocks if waited on from the main thread; stopping+clearing above is
+    # sufficient to prevent new work from starting.
+    if plugin.loader:
+        if plugin.loader.avatar_worker:
+            plugin.loader.avatar_worker.cancel()
+        plugin.loader.avatar_runner_pool.waitForDone(15000)
     plugin.unload()
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from qgis.core import QgsApplication, QgsAuthMethodConfig, QgsProject
 from qgis.gui import QgsLayerTreeMapCanvasBridge, QgsMapCanvas, QgsMessageBar
-from qgis.PyQt.QtCore import QSettings, QThread
+from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import (
     QMainWindow,
     QMenu,
@@ -81,14 +81,6 @@ def qgis_application() -> QgsApplication:
     yield qgs
 
     qgs.processEvents()
-    # Give any worker threads that escaped cleanup()'s 500ms waitForDone a
-    # moment to finish before the QgsApplication is destroyed.  We pump
-    # events rather than sleeping so Qt can deliver the replies that unblock
-    # those threads.  100ms repeated 5 times matches the original
-    # processEvents() behaviour while providing a wider safety margin.
-    for _ in range(5):
-        QThread.msleep(100)
-        qgs.processEvents()
     qgs.exitQgis()
 
 
@@ -214,10 +206,13 @@ def plugin(qgis_iface, qgis_application):
     if plugin.loader:
         plugin.loader.persistent_scheduler.stop()
         plugin.loader.persistent_scheduler.clear()
-    # Stop the auto-refresh timer before unload destroys the widgets it
-    # accesses.  Without this, the processEvents() calls below can fire the
-    # timer against already-deleted Qt objects.
+    # Stop the auto-refresh timer and remove the window event filter before
+    # unload.  Both can trigger auto_refresh() -> fetch_and_populate() ->
+    # NetworkManager.fetch() during any processEvents() spin, including the
+    # one inside delete_project() in rana_project teardown.  Removing the
+    # filter also prevents WindowActivate events from firing during teardown.
     if plugin.rana_browser:
         plugin.rana_browser.refresh_timer.stop()
+        plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
     plugin.unload()
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -214,5 +214,10 @@ def plugin(qgis_iface, qgis_application):
     if plugin.loader:
         plugin.loader.persistent_scheduler.stop()
         plugin.loader.persistent_scheduler.clear()
+    # Stop the auto-refresh timer before unload destroys the widgets it
+    # accesses.  Without this, the processEvents() calls below can fire the
+    # timer against already-deleted Qt objects.
+    if plugin.rana_browser:
+        plugin.rana_browser.refresh_timer.stop()
     plugin.unload()
     qgis_application.processEvents()

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from qgis.core import QgsApplication, QgsAuthMethodConfig, QgsProject
 from qgis.gui import QgsLayerTreeMapCanvasBridge, QgsMapCanvas, QgsMessageBar
-from qgis.PyQt.QtCore import QSettings
+from qgis.PyQt.QtCore import QSettings, QThread
 from qgis.PyQt.QtWidgets import (
     QMainWindow,
     QMenu,
@@ -81,6 +81,14 @@ def qgis_application() -> QgsApplication:
     yield qgs
 
     qgs.processEvents()
+    # Give any worker threads that escaped cleanup()'s 500ms waitForDone a
+    # moment to finish before the QgsApplication is destroyed.  We pump
+    # events rather than sleeping so Qt can deliver the replies that unblock
+    # those threads.  100ms repeated 5 times matches the original
+    # processEvents() behaviour while providing a wider safety margin.
+    for _ in range(5):
+        QThread.msleep(100)
+        qgs.processEvents()
     qgs.exitQgis()
 
 
@@ -200,16 +208,11 @@ def plugin(qgis_iface, qgis_application):
     plugin.initGui()
     yield plugin
 
-    plugin.unload()
-    # Process any queued cancel signals before waiting
-    qgis_application.processEvents()
-    # Wait for background threads to finish before QGIS teardown.
-    # loader.cleanup() uses waitForDone(500) which is too short when a
-    # network request is in-flight. We wait here with a longer timeout so
-    # the worker thread is guaranteed dead before exitQgis() runs, avoiding
-    # a segfault or hang caused by the thread accessing a destroyed
-    # QgsApplication.
+    # Stop the persistent scheduler timer and drain its task queue before
+    # unload so no new network requests are dispatched into worker threads
+    # during teardown.
     if plugin.loader:
-        plugin.loader.avatar_runner_pool.waitForDone(15000)
-        plugin.loader.persistent_scheduler.thread_pool.waitForDone(15000)
+        plugin.loader.persistent_scheduler.stop()
+        plugin.loader.persistent_scheduler.clear()
+    plugin.unload()
     qgis_application.processEvents()

--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -350,7 +350,6 @@ def test_select_download_and_delete(plugin, qtbot, request, rana_project):
     )
 
 
-@pytest.mark.skip(reason="Fails on CI")
 def test_upload_case_conflict(plugin, qtbot, request, rana_project):
     """Uploading a file whose name matches an existing server file case-insensitively
     should warn the user and not complete the upload."""

--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -94,12 +94,12 @@ def rana_project(plugin, login):
     plugin.rana_browser.refresh()
     print(result)
     yield result["name"]
-    # Stop the auto-refresh timer before the delete_project() network call.
-    # delete_project() spins QCoreApplication.processEvents() while waiting
-    # for the reply; if the timer fires during that spin it starts a nested
-    # fetch_and_populate() which can deadlock with the outer processEvents()
-    # loop.
+    # Disable auto-refresh triggers before delete_project() to prevent a
+    # nested fetch_and_populate() from firing inside delete_project()'s
+    # processEvents() spin loop.  plugin fixture teardown does the same but
+    # runs after this fixture, so we must do it here first.
     plugin.rana_browser.refresh_timer.stop()
+    plugin.rana_browser.window().removeEventFilter(plugin.rana_browser)
     delete_project(result["id"])
 
 

--- a/e2e/test_api.py
+++ b/e2e/test_api.py
@@ -94,6 +94,12 @@ def rana_project(plugin, login):
     plugin.rana_browser.refresh()
     print(result)
     yield result["name"]
+    # Stop the auto-refresh timer before the delete_project() network call.
+    # delete_project() spins QCoreApplication.processEvents() while waiting
+    # for the reply; if the timer fires during that spin it starts a nested
+    # fetch_and_populate() which can deadlock with the outer processEvents()
+    # loop.
+    plugin.rana_browser.refresh_timer.stop()
     delete_project(result["id"])
 
 

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -202,11 +202,12 @@ class Loader(QObject):
 
     def cleanup(self):
         self.persistent_scheduler.stop()
+        self.persistent_scheduler.clear()
         if self.avatar_runner_pool is not None:
             if self.avatar_worker is not None:
                 self.avatar_worker.cancel()
             self.avatar_runner_pool.clear()
-            self.avatar_runner_pool.waitForDone(500)  # short grace period (ms)
+            self.avatar_runner_pool.waitForDone(5000)  # not so short grace period (ms)
 
     def __del__(self):
         self.cleanup()

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -206,7 +206,9 @@ class Loader(QObject):
             if self.avatar_worker is not None:
                 self.avatar_worker.cancel()
             self.avatar_runner_pool.clear()
-            self.avatar_runner_pool.waitForDone(5000)  # not so short grace period (ms)
+            self.avatar_runner_pool.waitForDone(
+                15000
+            )  # > request transfer timeout (10s)
 
     def __del__(self):
         self.cleanup()

--- a/rana_qgis_plugin/loader.py
+++ b/rana_qgis_plugin/loader.py
@@ -202,7 +202,6 @@ class Loader(QObject):
 
     def cleanup(self):
         self.persistent_scheduler.stop()
-        self.persistent_scheduler.clear()
         if self.avatar_runner_pool is not None:
             if self.avatar_worker is not None:
                 self.avatar_worker.cancel()

--- a/rana_qgis_plugin/rana_qgis_plugin.py
+++ b/rana_qgis_plugin/rana_qgis_plugin.py
@@ -277,6 +277,9 @@ class RanaQgisPlugin:
         QgsApplication.processingRegistry().removeProvider(self.provider)
         menu = self.iface.mainWindow().getPluginMenu(PLUGIN_NAME)
         menu.clear()
+        if self.rana_browser:
+            self.rana_browser.refresh_timer.stop()
+            self.rana_browser.window().removeEventFilter(self.rana_browser)
         self.iface.removeToolBarIcon(self.action)
         if self.dock_widget:
             self.iface.removeDockWidget(self.dock_widget)

--- a/rana_qgis_plugin/workers/persistent.py
+++ b/rana_qgis_plugin/workers/persistent.py
@@ -62,7 +62,7 @@ class PersistentTaskScheduler:
         self.timer.stop()
         self.clear()
         self.thread_pool.clear()
-        self.thread_pool.waitForDone(5000)
+        self.thread_pool.waitForDone(15000)  # > request transfer timeout (10s)
 
     def clear(self):
         self.tasks = []

--- a/rana_qgis_plugin/workers/persistent.py
+++ b/rana_qgis_plugin/workers/persistent.py
@@ -60,6 +60,9 @@ class PersistentTaskScheduler:
 
     def stop(self):
         self.timer.stop()
+        self.clear()
+        self.thread_pool.clear()
+        self.thread_pool.waitForDone(5000)
 
     def clear(self):
         self.tasks = []

--- a/xvfb-startup.sh
+++ b/xvfb-startup.sh
@@ -10,6 +10,7 @@ fluxbox &
 
 # Start VNC server for visual inspection (optional)
 x11vnc -display :99 -nopw -forever -shared &
+X11VNC_PROC=$!
 
 ffmpeg -loglevel error -y -f x11grab -video_size 1920x1080 -framerate 15 -i :99 -c:v libx264 -preset veryfast -crf 28 -pix_fmt yuv420p -movflags +faststart output.mp4 &
 FFMPEG_PROC=$!
@@ -19,9 +20,10 @@ sleep 1
 "$@"
 EXIT_CODE=$?   # Capture the exit code of pytest
 
-# Stop ffmpeg and xvfb cleanly
+# Stop ffmpeg, x11vnc and xvfb cleanly
 kill -INT $FFMPEG_PROC
 wait $FFMPEG_PROC
+kill $X11VNC_PROC
 kill $XVFB_PROC
 
 # Exit the container with pytest's exit code

--- a/xvfb-startup.sh
+++ b/xvfb-startup.sh
@@ -22,9 +22,15 @@ EXIT_CODE=$?   # Capture the exit code of pytest
 
 # Stop ffmpeg, x11vnc and xvfb cleanly
 kill -INT $FFMPEG_PROC
-wait $FFMPEG_PROC
-kill $X11VNC_PROC
-kill $XVFB_PROC
+# Wait up to 10 seconds for ffmpeg to finalize, then force kill
+for i in $(seq 1 10); do
+    kill -0 $FFMPEG_PROC 2>/dev/null || break
+    sleep 1
+done
+kill -9 $FFMPEG_PROC 2>/dev/null
+wait $FFMPEG_PROC 2>/dev/null
+kill $X11VNC_PROC 2>/dev/null
+kill $XVFB_PROC 2>/dev/null
 
 # Exit the container with pytest's exit code
 exit $EXIT_CODE


### PR DESCRIPTION
Improve plugin teardown:
* Explicitly stop and clear persistent scheduler to prevent active monitoring during teardown
* Explicitly stop avatar worker and wait until done to prevent unloading the widget with an active avatar worker
* Stop refresh time and remove related event filter to prevent refresh while the widget is being closed
* Stop refresh time and remove related event filter to prevent refresh while deleting the project

Ensure VNC process is killed to prevent hanging in github action.