### PR TITLE
Fixed default ordering of folders in FilesBrowser (nens/rana#4574)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 -------------------
 
 - Append plugin version to "user_agent" in requests for improved logging (#338)
-
+- Fixed default ordering of folders in FilesBrowser (nens/rana#4574)
 
 1.2.16 (2026-07-08)
 -------------------

--- a/rana_qgis_plugin/widgets/files_browser.py
+++ b/rana_qgis_plugin/widgets/files_browser.py
@@ -111,7 +111,7 @@ class FileBrowserModel(QStandardItemModel):
         # Sort directories always by name (col 1), files by the requested column
         directories.sort(
             key=lambda x: x[1],
-            reverse=(order == Qt.SortOrder.DescendingOrder),
+            reverse=(column == 1 and order == Qt.SortOrder.DescendingOrder),
         )
         files.sort(key=lambda x: x[1], reverse=(order == Qt.SortOrder.DescendingOrder))
         # Always add directories first, then files


### PR DESCRIPTION
The folders were initially sorted descending (alphabetically), this was because the sort function was called (probably internally with the Descending parameter (newest on top). Even though in that case column = 4, it still sorted the folders descending.