### PR TITLE
Gracefully handle non-zip schematisation downloads and fix file removal

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 - Prevent auto-refresh on closing dialogs, wizards, etc in qgis
 - Prevent crashes on loading file view with missing data (nens/rana#4676)
 - Properly handle failure to retrieve schematisation from Rana (nens/rana-qgis-plugin#430)
+- Handle schematisations where sqlite endpoint does not return a zip (nens/rana#4720)
 
 
 1.2.17 (2026-07-16)

--- a/rana_qgis_plugin/simulation/utils.py
+++ b/rana_qgis_plugin/simulation/utils.py
@@ -10,7 +10,7 @@ from enum import Enum
 from operator import attrgetter
 from time import sleep
 from typing import List
-from zipfile import ZIP_DEFLATED, ZipFile
+from zipfile import ZIP_DEFLATED, ZipFile, is_zipfile
 
 import requests
 from qgis.core import QgsVectorLayer
@@ -318,9 +318,13 @@ def unzip_archive(zip_filepath, location=None):
     """Unzip archive content."""
     if not location:
         location = os.path.dirname(zip_filepath)
+    # if zip_filepath is not a proper zip file, just return the file path as a list
+    if not is_zipfile(zip_filepath):
+        return [zip_filepath]
     with ZipFile(zip_filepath, "r") as zf:
         content_list = zf.namelist()
         zf.extractall(location)
+        os.remove(zip_filepath)
         return content_list
 
 
@@ -894,7 +898,6 @@ def download_required_files(
         _emit_progress()
         get_download_file(sqlite_download, zip_filepath)
         content_list = unzip_archive(zip_filepath)
-        os.remove(zip_filepath)
         schematisation_db_file = content_list[0]
         current_progress += 1
         _emit_progress("Downloaded schematisation database")

--- a/rana_qgis_plugin/workers/download.py
+++ b/rana_qgis_plugin/workers/download.py
@@ -428,13 +428,13 @@ class SchematisationGeopackageDownloader(BaseDownloader):
         super().download_file(signals, download_file)
 
     def postprocess(self):
-        # Extract schematisation from zip
         zip_file = self.download_context.local_file_path
-        if zip_file.suffix == ".zip":
+        # Extract schematisation from zipped archive
+        # If the downloaded file is not a zip, we assume it is already a geopackage and skip extraction
+        if zipfile.is_zipfile(zip_file):
             with zipfile.ZipFile(zip_file, "r") as zip_ref:
                 zip_ref.extractall(self.download_context.local_dir)
-        zip_file.unlink()
-
+            zip_file.unlink()
         # Assert that there is only one file in the directory
         extracted_files = list(self.download_context.local_dir.iterdir())
         assert len(extracted_files) == 1, (


### PR DESCRIPTION
This prevents errors when the schematisation sqlite endpoint returns a geopackage (not a zip). unzip_archive now returns the original file if it isn't a zip and only removes the archive after successful extraction; the downloader now detects zip content with zipfile.is_zipfile and skips extraction for non-zips. HISTORY.rst updated.

Manual test: export a schematisation where the sqlite endpoint returns a gpkg (non-zip) and verify the file is used/imported without errors; also test a normal zipped schematisation to ensure extraction still works. (see linked ticket)

Closes https://github.com/nens/rana/issues/4720