### PR TITLE
Modify docker setup to not use the same image as main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build QGIS Docker image
-        run: docker compose build qgis
+        run: docker compose -f docker-compose.qgis4.yml build qgis
 
       - name: Run unit tests
         run: 
-          docker compose run --rm qgis pytest -v tests
+          docker compose -f docker-compose.qgis4.yml run --rm qgis pytest -v tests
 
 # Skip because they do not work with qgis 4.x
 #      - name: Run e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM qgis/qgis:4.2
+ARG QGIS_VERSION=3.28
+FROM qgis/qgis:${QGIS_VERSION}
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-setuptools \
     python3-pyqt5.qtwebsockets \

--- a/README.md
+++ b/README.md
@@ -71,25 +71,44 @@ these QGIS styles to Maplibre styles for the Rana Web client that is called
 ## Local development notes
 
 On Linux, local development happens with docker to make sure we're working in a nicely
-isolated environment. To start the development environment, run the following commands::
+isolated environment.
 
-    $ docker compose build
+### Building the Docker image
 
-The unit and e2e tests also run in this docker container. They can be started with 
+For QGIS 4.x (this branch):
 
-    $ docker compose run --rm qgis pytest -v tests
-    $ docker compose run --rm --service-ports qgis pytest -v e2e
-
-Note that the e2e tests require authentication, therefore use the following `docker-compose.override.yml`:
+```bash
+docker compose -f docker-compose.qgis4.yml build
 ```
+
+### Running tests
+
+Unit tests with QGIS 4.x:
+
+```bash
+docker compose -f docker-compose.qgis4.yml run --rm qgis pytest -v tests
+```
+
+E2E tests (requires authentication):
+
+```bash
+docker compose -f docker-compose.qgis4.yml run --rm --service-ports qgis pytest -v e2e
+```
+
+To run e2e tests, you need a `docker-compose.override.yml` with your personal access token:
+
+```yaml
 services:
   qgis:
     environment:
       RANA_PAK: "ENTER_YOUR_PERSONAL_ACCESS_TOKEN_HERE"
 ```
 
-Fuerhermore, note that the e2e tests can be visually inspected using `vncviewer`:
-    $ vncviewer localhost:5900
+Optionally, visually inspect e2e tests using `vncviewer`:
+
+```bash
+vncviewer localhost:5900
+```
 
 
 ## Development and test settings

--- a/docker-compose.qgis4.yml
+++ b/docker-compose.qgis4.yml
@@ -1,0 +1,20 @@
+services:
+  qgis:
+    build:
+      context: .
+      args:
+        QGIS_VERSION: "4.2"
+    ports:
+      - "7070:7070"
+      - "5900:5900" # x11vnc
+    tmpfs:
+      - /tmp
+      - /tmp/.X11-unix
+    environment:
+      RANA_PAK: ${RANA_PAK}
+    volumes:
+      - .:/tests_directory/
+      - profile-dir:/root/.local/share/QGIS/QGIS3/profiles/default
+
+volumes:
+  profile-dir:


### PR DESCRIPTION
* Make qgis version a parameter in Docker file
* Add docker-compose.qgis4.yml and use that in CI
* Add instructions to use docker-compose.qgis4.yml in readme and point agents.md to always refer to the readme for testing (not in repo)