### PR TITLE
Revert fix for non-zip schematisations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 1.2.19 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Revert fix for nens/rana#4720 becuase it completely breaks opening schematisations on windows
 
 
 1.2.18 (2026-08-06)

--- a/rana_qgis_plugin/simulation/utils.py
+++ b/rana_qgis_plugin/simulation/utils.py
@@ -10,7 +10,7 @@ from enum import Enum
 from operator import attrgetter
 from time import sleep
 from typing import List
-from zipfile import ZIP_DEFLATED, ZipFile, is_zipfile
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import requests
 from qgis.core import QgsVectorLayer
@@ -318,13 +318,9 @@ def unzip_archive(zip_filepath, location=None):
     """Unzip archive content."""
     if not location:
         location = os.path.dirname(zip_filepath)
-    # if zip_filepath is not a proper zip file, just return the file path as a list
-    if not is_zipfile(zip_filepath):
-        return [zip_filepath]
     with ZipFile(zip_filepath, "r") as zf:
         content_list = zf.namelist()
         zf.extractall(location)
-        os.remove(zip_filepath)
         return content_list
 
 
@@ -898,6 +894,7 @@ def download_required_files(
         _emit_progress()
         get_download_file(sqlite_download, zip_filepath)
         content_list = unzip_archive(zip_filepath)
+        os.remove(zip_filepath)
         schematisation_db_file = content_list[0]
         current_progress += 1
         _emit_progress("Downloaded schematisation database")

--- a/rana_qgis_plugin/workers/download.py
+++ b/rana_qgis_plugin/workers/download.py
@@ -428,13 +428,13 @@ class SchematisationGeopackageDownloader(BaseDownloader):
         super().download_file(signals, download_file)
 
     def postprocess(self):
+        # Extract schematisation from zip
         zip_file = self.download_context.local_file_path
-        # Extract schematisation from zipped archive
-        # If the downloaded file is not a zip, we assume it is already a geopackage and skip extraction
-        if zipfile.is_zipfile(zip_file):
+        if zip_file.suffix == ".zip":
             with zipfile.ZipFile(zip_file, "r") as zip_ref:
                 zip_ref.extractall(self.download_context.local_dir)
-            zip_file.unlink()
+        zip_file.unlink()
+
         # Assert that there is only one file in the directory
         extracted_files = list(self.download_context.local_dir.iterdir())
         assert len(extracted_files) == 1, (


### PR DESCRIPTION
Fix breaks opening schematisations on windows: TOPDESK 2608 0022.

Because the issue that this commit should fix is an edge case and this is now causing major issues we revert it and reconsider the fix.

Reverts eef55c57e90c623f9ff549d52639da75018a2aa5